### PR TITLE
Fixed DOI link in Generalinfo

### DIFF
--- a/src/components/Records/Record/GeneralInfo.vue
+++ b/src/components/Records/Record/GeneralInfo.vue
@@ -49,7 +49,7 @@
             </h3>
             <a
               v-if="currentRecord['fairsharingRecord'].doi"
-              :href="currentRecord['fairsharingRecord'].doi"
+              :href="generateDoiLink(currentRecord['fairsharingRecord'].doi)"
               target="_blank"
             >
               {{ currentRecord['fairsharingRecord'].doi }}
@@ -173,6 +173,11 @@ export default {
   mixins: [stringUtils],
   computed: {
     ...mapState("record", ["currentRecord"])
+  },
+  methods: {
+    generateDoiLink(doi) {
+      return `https://doi.org/${doi}`
+    }
   }
 }
 </script>

--- a/tests/unit/components/Records/Record/GeneralInfo.spec.js
+++ b/tests/unit/components/Records/Record/GeneralInfo.spec.js
@@ -9,7 +9,8 @@ Record.state.currentRecord["fairsharingRecord"] = {
     metadata: {
         year_creation: 1912,
     },
-    abbreviation:  "MGY"
+    abbreviation:  "MGY",
+    doi: 'FAIRsharing.wibble'
 };
 const $store = new Vuex.Store({
     modules: {
@@ -31,6 +32,11 @@ describe("GeneralInfo.vue", function(){
         expect(wrapper.name()).toMatch("GeneralInfo");
         expect(wrapper.vm.currentRecord['fairsharingRecord'].metadata.year_creation).toEqual(1912);
         expect(wrapper.vm.currentRecord['fairsharingRecord'].abbreviation).toMatch("MGY");
+    });
+
+    it("generates correct doi link", () => {
+        let doiLink = `https://doi.org/${wrapper.vm.currentRecord['fairsharingRecord'].doi}`;
+        expect(wrapper.vm.generateDoiLink(wrapper.vm.currentRecord['fairsharingRecord'].doi)).toEqual(doiLink);
     });
 
 });


### PR DESCRIPTION
Now links to https://doi.org/${doi}.