### PR TITLE
Edit form: Changed licences and support to match organisations stylin…

### DIFF
--- a/src/components/Editor/EditLicences.vue
+++ b/src/components/Editor/EditLicences.vue
@@ -41,31 +41,10 @@
           </v-alert>
         </v-row>
         <v-row>
-          <v-col class="col-12 pt-0">
-            <v-btn
-              class="primary"
-              style="display:inline-block"
-              fab
-              x-small
-              dark
-              @click="addLicence()"
-            >
-              <v-icon>fa-plus</v-icon>
-            </v-btn>
-            <div
-              class="ml-3"
-              style="display:inline-block"
-            >
-              ADD A NEW LICENCE
-            </div>
-            <v-divider />
-          </v-col>
-        </v-row>
-        <v-row>
           <v-col
             v-for="(licence, licenceIndex) in currentLicences"
             :key="'licence_' + licenceIndex"
-            class="col-4"
+            class="col-3"
           >
             <v-card height="100%">
               <v-card-text style="height:80%">
@@ -89,7 +68,7 @@
                       </v-row>
                       <v-row justify="center">
                         <v-btn
-                          class="green white--text my-3"
+                          elass="green white--text my-3"
                           @click="createNewLicence(licence, licenceIndex)"
                         >
                           Create a new licence
@@ -119,22 +98,38 @@
               </v-card-text>
               <v-card-actions>
                 <v-btn
-                  style="display:inline-block"
-                  fab
-                  x-small
-                  dark
-                  class="red"
-                  @click="removeLicence(licenceIndex)"
+                    class="error mb-3 ml-2"
+                    @click="removeLicence(licenceIndex)"
                 >
-                  <v-icon> fa-minus </v-icon>
+                  <v-icon left>
+                    fa-minus-circle
+                  </v-icon>
+                  Remove Licence
                 </v-btn>
-                <div
-                  class="ml-3 pt-1"
-                  style="display:inline-block"
-                >
-                  REMOVE LICENCE
-                </div>
               </v-card-actions>
+            </v-card>
+          </v-col>
+
+          <!-- ADDING NEW ITEMS -->
+          <v-col class="col-sm-12 col-md-12 col-lg-4 col-xl-3">
+            <v-card
+                height="100%"
+                class="newRel green--text"
+                style="cursor: pointer"
+                min-height="383px"
+                @click="addLicence()"
+            >
+              <div class="mb-4">
+                <v-icon
+                    x-large
+                    class="green--text icon--xxl"
+                >
+                  fa-plus-circle
+                </v-icon>
+              </div>
+              <div class="text-h4 text-center">
+                Add a new licence
+              </div>
             </v-card>
           </v-col>
         </v-row>

--- a/src/components/Editor/EditSupport.vue
+++ b/src/components/Editor/EditSupport.vue
@@ -29,27 +29,6 @@
       <v-card-text>
         <v-container fluid>
           <v-row>
-            <v-col class="col-12 pt-0">
-              <v-btn
-                class="primary"
-                style="display:inline-block"
-                fab
-                x-small
-                dark
-                @click="addContact()"
-              >
-                <v-icon>fa-plus</v-icon>
-              </v-btn>
-              <div
-                class="ml-3"
-                style="display:inline-block"
-              >
-                ADD A NEW CONTACT
-              </div>
-              <v-divider />
-            </v-col>
-          </v-row>
-          <v-row>
             <v-col
               v-for="(contact, contactIndex) in contacts"
               :key="'contact_' + contactIndex"
@@ -80,22 +59,36 @@
                 </v-card-text>
                 <v-card-actions>
                   <v-btn
-                    style="display:inline-block"
-                    fab
-                    x-small
-                    dark
-                    class="red"
+                    class="error mb-3 ml-2"
                     @click="removeContact(contact)"
                   >
-                    <v-icon> fa-minus </v-icon>
+                    <v-icon left>
+                      fa-minus-circle
+                    </v-icon>
+                    Remove Contact
                   </v-btn>
-                  <div
-                    class="ml-3 pt-1"
-                    style="display:inline-block"
-                  >
-                    REMOVE CONTACT
-                  </div>
                 </v-card-actions>
+              </v-card>
+            </v-col>
+            <!-- ADDING NEW ITEMS -->
+            <v-col class="col-sm-12 col-md-12 col-lg-4 col-xl-3">
+              <v-card
+                height="100%"
+                class="newRel green--text"
+                style="cursor: pointer"
+                @click="addContact()"
+              >
+                <div class="mb-4">
+                  <v-icon
+                    x-large
+                    class="green--text icon--xxl"
+                  >
+                    fa-plus-circle
+                  </v-icon>
+                </div>
+                <div class="text-h4 text-center">
+                  Add a new contact
+                </div>
               </v-card>
             </v-col>
           </v-row>


### PR DESCRIPTION
This changes the edit form styling to use the same "new [type]" card as for organisations.
Note:
- I haven't implemented card disablement on loading (not sure if it's needed for these).
- Eventually the support/contacts section will have to be re-done; see https://github.com/FAIRsharing/fairsharing.github.io/issues/575
This should at least please curators for now, though. 