### PR TITLE
Hack to correct coverage locally.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,34 +2,58 @@ import Vue from "vue";
 import VueRouter from "vue-router";
 import store from '@/store'
 
-
+/* istanbul ignore next */
 const Home = () => import(/* webpackChunkName: "home-chunk" */ '@/views/Home/Home.vue');
+/* istanbul ignore next */
 const NotFound = () => import(/* webpackChunkName: "home-chunk" */  "@/views/Errors/404");
 
+/* istanbul ignore next */
 const Record =  () => import(/* webpackChunkName: "record-chunk" */ '@/views/Records/Record');
+/* istanbul ignore next */
 const Records =  () => import(/* webpackChunkName: "records-chunk" */ '@/views/Records/Records');
+/* istanbul ignore next */
 const NewRecord = () => import(/* webpackChunkName: "newRecord-chunk" */ '@/views/CreateRecord/NewRecord');
+/* istanbul ignore next */
 const Editor = () => import(/* webpackChunkName: "editRecord-chunk" */ "@/views/CreateRecord/Editor");
 
+/* istanbul ignore next */
 const Login = () => import(/* webpackChunkName: "login-chunk" */ '@/views/Users/Login/Login');
+/* istanbul ignore next */
 const Signup =  () => import(/* webpackChunkName: "signUp-chunk" */ "@/views/Users/Signup");
+/* istanbul ignore next */
 const ConfirmAccount =  () => import(/* webpackChunkName: "confirmAccount-chunk" */ "@/views/Users/ConfirmAccount.vue");
+/* istanbul ignore next */
 const ResendConfirmation = () => import(/* webpackChunkName: "resentEmail-chunk" */ "@/views/Users/ResendConfirmation.vue");
+/* istanbul ignore next */
 const User =  () => import(/* webpackChunkName: "user-chunk" */ "@/views/Users/User.vue");
+/* istanbul ignore next */
 const Curator = () => import(/* webpackChunkName: "curator-chunk" */ "@/views/Curators/Curator.vue");
+/* istanbul ignore next */
 const RequestNewPassword = () =>  import(/* webpackChunkName: "newPwd-chunk" */ "@/views/Users/RequestNewPassword");
+/* istanbul ignore next */
 const ResetPassword = () =>  import(/* webpackChunkName: "resetPwd-chunk" */ "@/views/Users/ResetPassword");
+/* istanbul ignore next */
 const EditProfile = () =>  import(/* webpackChunkName: "editProfile-chunk" */ "@/views/Users/EditProfile");
+/* istanbul ignore next */
 const OauthLogin = () =>  import(/* webpackChunkName: "Oauth-chunk" */ "@/views/Users/Login/OauthLogin.vue");
+/* istanbul ignore next */
 const LoginFailure = () =>  import(/* webpackChunkName: "failedLogin-chunk" */ "@/views/Users/Login/LoginFailure");
 
+/* istanbul ignore next */
 const Stat =  () => import(/* webpackChunkName: "stat-chunk" */ '@/views/Stats/Statistics.vue');
+/* istanbul ignore next */
 const Community =  () => import(/* webpackChunkName: "community-chunk" */ '@/views/Static/Community/Community');
+/* istanbul ignore next */
 const Stakeholders =  () => import(/* webpackChunkName: "stakeholders-chunk" */ '@/views/Static/Stakeholders/Stakeholders');
+/* istanbul ignore next */
 const Timeline =  () => import(/* webpackChunkName: "timeline-chunk" */ '@/views/Static/Timeline/Timeline');
+/* istanbul ignore next */
 const License =  () => import(/* webpackChunkName: "licence-chunk" */ '@/views/Static/License/License');
+/* istanbul ignore next */
 const Terms =  () => import(/* webpackChunkName: "tos-chunk" */ '@/views/Static/TermOfUse/TermsOfUse');
+/* istanbul ignore next */
 const Educational =  () => import(/* webpackChunkName: "edu-chunk" */ '@/views/Static/Educational/Educational');
+/* istanbul ignore next */
 const Privacy =  () => import(/* webpackChunkName: "privacy-chunk" */ '@/views/Static/Privacy/Privacy');
 Vue.use(VueRouter);
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,32 +2,9 @@ import Vue from "vue";
 import VueRouter from "vue-router";
 import store from '@/store'
 
-let Home;
-let NotFound;
-let Record;
-let Records
-let NewRecord;
-let Editor;
-let Login;
-let Signup;
-let ConfirmAccount;
-let ResendConfirmation;
-let User;
-let Curator;
-let RequestNewPassword;
-let ResetPassword;
-let EditProfile;
-let OauthLogin;
-let LoginFailure;
-let Stat;
-let Community;
-let Stakeholders;
-let Timeline;
-let License;
-let Terms;
-let Educational;
-let Privacy;
-
+let Home, NotFound, Record, Records, NewRecord, Editor, Login, Signup, ConfirmAccount, ResendConfirmation, User,
+    Curator, RequestNewPassword, ResetPassword, EditProfile, OauthLogin, LoginFailure, Stat, Community, Stakeholders,
+    Timeline, License, Terms, Educational, Privacy;
 /*
  * This block is ignored because, though coverage shows at 100% in CI, it does not do so locally.
  * Assigning things here and freezing them rather than creating consts above allows this entire function

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,59 +2,92 @@ import Vue from "vue";
 import VueRouter from "vue-router";
 import store from '@/store'
 
-/* istanbul ignore next */
-const Home = () => import(/* webpackChunkName: "home-chunk" */ '@/views/Home/Home.vue');
-/* istanbul ignore next */
-const NotFound = () => import(/* webpackChunkName: "home-chunk" */  "@/views/Errors/404");
+let Home;
+let NotFound;
+let Record;
+let Records
+let NewRecord;
+let Editor;
+let Login;
+let Signup;
+let ConfirmAccount;
+let ResendConfirmation;
+let User;
+let Curator;
+let RequestNewPassword;
+let ResetPassword;
+let EditProfile;
+let OauthLogin;
+let LoginFailure;
+let Stat;
+let Community;
+let Stakeholders;
+let Timeline;
+let License;
+let Terms;
+let Educational;
+let Privacy;
 
+/*
+ * This block is ignored because, though coverage shows at 100% in CI, it does not do so locally.
+ * Assigning things here and freezing them rather than creating consts above allows this entire function
+ * to be ignored by local coverage.
+ */
 /* istanbul ignore next */
-const Record =  () => import(/* webpackChunkName: "record-chunk" */ '@/views/Records/Record');
-/* istanbul ignore next */
-const Records =  () => import(/* webpackChunkName: "records-chunk" */ '@/views/Records/Records');
-/* istanbul ignore next */
-const NewRecord = () => import(/* webpackChunkName: "newRecord-chunk" */ '@/views/CreateRecord/NewRecord');
-/* istanbul ignore next */
-const Editor = () => import(/* webpackChunkName: "editRecord-chunk" */ "@/views/CreateRecord/Editor");
+function dynamicImports() {
+    Home = () => import(/* webpackChunkName: "home-chunk" */ '@/views/Home/Home.vue');
+    Object.freeze(Home);
+    NotFound = () => import(/* webpackChunkName: "home-chunk" */  "@/views/Errors/404");
+    Object.freeze(NotFound);
+    Record =  () => import(/* webpackChunkName: "record-chunk" */ '@/views/Records/Record');
+    Object.freeze(Record);
+    Records =  () => import(/* webpackChunkName: "records-chunk" */ '@/views/Records/Records');
+    Object.freeze(Records);
+    NewRecord = () => import(/* webpackChunkName: "newRecord-chunk" */ '@/views/CreateRecord/NewRecord');
+    Object.freeze(NewRecord);
+    Editor = () => import(/* webpackChunkName: "editRecord-chunk" */ "@/views/CreateRecord/Editor");
+    Object.freeze(Editor);
+    Login = () => import(/* webpackChunkName: "login-chunk" */ '@/views/Users/Login/Login');
+    Object.freeze(Login);
+    Signup =  () => import(/* webpackChunkName: "signUp-chunk" */ "@/views/Users/Signup");
+    Object.freeze(Signup);
+    ConfirmAccount =  () => import(/* webpackChunkName: "confirmAccount-chunk" */ "@/views/Users/ConfirmAccount.vue");
+    Object.freeze(ConfirmAccount);
+    ResendConfirmation = () => import(/* webpackChunkName: "resentEmail-chunk" */ "@/views/Users/ResendConfirmation.vue");
+    Object.freeze(ResendConfirmation);
+    User =  () => import(/* webpackChunkName: "user-chunk" */ "@/views/Users/User.vue");
+    Object.freeze(User);
+    Curator = () => import(/* webpackChunkName: "curator-chunk" */ "@/views/Curators/Curator.vue");
+    Object.freeze(Curator);
+    RequestNewPassword = () =>  import(/* webpackChunkName: "newPwd-chunk" */ "@/views/Users/RequestNewPassword");
+    Object.freeze(RequestNewPassword);
+    ResetPassword = () =>  import(/* webpackChunkName: "resetPwd-chunk" */ "@/views/Users/ResetPassword");
+    Object.freeze(ResetPassword);
+    EditProfile = () =>  import(/* webpackChunkName: "editProfile-chunk" */ "@/views/Users/EditProfile");
+    Object.freeze(EditProfile);
+    OauthLogin = () =>  import(/* webpackChunkName: "Oauth-chunk" */ "@/views/Users/Login/OauthLogin.vue");
+    Object.freeze(OauthLogin);
+    LoginFailure = () =>  import(/* webpackChunkName: "failedLogin-chunk" */ "@/views/Users/Login/LoginFailure");
+    Object.freeze(LoginFailure);
+    Stat =  () => import(/* webpackChunkName: "stat-chunk" */ '@/views/Stats/Statistics.vue');
+    Object.freeze(Stat);
+    Community =  () => import(/* webpackChunkName: "community-chunk" */ '@/views/Static/Community/Community');
+    Object.freeze(Community);
+    Stakeholders =  () => import(/* webpackChunkName: "stakeholders-chunk" */ '@/views/Static/Stakeholders/Stakeholders');
+    Object.freeze(Stakeholders);
+    Timeline =  () => import(/* webpackChunkName: "timeline-chunk" */ '@/views/Static/Timeline/Timeline');
+    Object.freeze(Timeline);
+    License =  () => import(/* webpackChunkName: "licence-chunk" */ '@/views/Static/License/License');
+    Object.freeze(License);
+    Terms =  () => import(/* webpackChunkName: "tos-chunk" */ '@/views/Static/TermOfUse/TermsOfUse');
+    Object.freeze(Terms);
+    Educational =  () => import(/* webpackChunkName: "edu-chunk" */ '@/views/Static/Educational/Educational');
+    Object.freeze(Educational);
+    Privacy =  () => import(/* webpackChunkName: "privacy-chunk" */ '@/views/Static/Privacy/Privacy');
+    Object.freeze(Privacy);
+}
 
-/* istanbul ignore next */
-const Login = () => import(/* webpackChunkName: "login-chunk" */ '@/views/Users/Login/Login');
-/* istanbul ignore next */
-const Signup =  () => import(/* webpackChunkName: "signUp-chunk" */ "@/views/Users/Signup");
-/* istanbul ignore next */
-const ConfirmAccount =  () => import(/* webpackChunkName: "confirmAccount-chunk" */ "@/views/Users/ConfirmAccount.vue");
-/* istanbul ignore next */
-const ResendConfirmation = () => import(/* webpackChunkName: "resentEmail-chunk" */ "@/views/Users/ResendConfirmation.vue");
-/* istanbul ignore next */
-const User =  () => import(/* webpackChunkName: "user-chunk" */ "@/views/Users/User.vue");
-/* istanbul ignore next */
-const Curator = () => import(/* webpackChunkName: "curator-chunk" */ "@/views/Curators/Curator.vue");
-/* istanbul ignore next */
-const RequestNewPassword = () =>  import(/* webpackChunkName: "newPwd-chunk" */ "@/views/Users/RequestNewPassword");
-/* istanbul ignore next */
-const ResetPassword = () =>  import(/* webpackChunkName: "resetPwd-chunk" */ "@/views/Users/ResetPassword");
-/* istanbul ignore next */
-const EditProfile = () =>  import(/* webpackChunkName: "editProfile-chunk" */ "@/views/Users/EditProfile");
-/* istanbul ignore next */
-const OauthLogin = () =>  import(/* webpackChunkName: "Oauth-chunk" */ "@/views/Users/Login/OauthLogin.vue");
-/* istanbul ignore next */
-const LoginFailure = () =>  import(/* webpackChunkName: "failedLogin-chunk" */ "@/views/Users/Login/LoginFailure");
-
-/* istanbul ignore next */
-const Stat =  () => import(/* webpackChunkName: "stat-chunk" */ '@/views/Stats/Statistics.vue');
-/* istanbul ignore next */
-const Community =  () => import(/* webpackChunkName: "community-chunk" */ '@/views/Static/Community/Community');
-/* istanbul ignore next */
-const Stakeholders =  () => import(/* webpackChunkName: "stakeholders-chunk" */ '@/views/Static/Stakeholders/Stakeholders');
-/* istanbul ignore next */
-const Timeline =  () => import(/* webpackChunkName: "timeline-chunk" */ '@/views/Static/Timeline/Timeline');
-/* istanbul ignore next */
-const License =  () => import(/* webpackChunkName: "licence-chunk" */ '@/views/Static/License/License');
-/* istanbul ignore next */
-const Terms =  () => import(/* webpackChunkName: "tos-chunk" */ '@/views/Static/TermOfUse/TermsOfUse');
-/* istanbul ignore next */
-const Educational =  () => import(/* webpackChunkName: "edu-chunk" */ '@/views/Static/Educational/Educational');
-/* istanbul ignore next */
-const Privacy =  () => import(/* webpackChunkName: "privacy-chunk" */ '@/views/Static/Privacy/Privacy');
+dynamicImports();
 Vue.use(VueRouter);
 
 let routes = [


### PR DESCRIPTION
There's been an irritating issue for a while where coverage is shown correctly as 100% online, but running tests locally show somewhere between 95-96%.
A possible hack to "fix" this is to exclude the offending lines from coverage. Unfortunately, the means of doing this is a bit ugly as it's not a single function that's causing it but instead a list of statements, each one of which must be commented.
I've left this as a draft PR as it's not necessarily something that's worth doing.
Please feel free to try it and comment, when time permits. 