### PR TITLE
Countries can be dismissed by click. #584.

### DIFF
--- a/src/components/Editor/EditGeneralInfo.vue
+++ b/src/components/Editor/EditGeneralInfo.vue
@@ -142,8 +142,8 @@
                 :hint="descriptions['countries']"
                 item-text="name"
                 item-value="name"
-                outlined
                 multiple
+                outlined
                 return-object
               >
                 <template v-slot:prepend>
@@ -163,7 +163,11 @@
 
                 <!-- autocomplete selected -->
                 <template v-slot:selection="data">
-                  <v-chip class="blue white--text">
+                  <v-chip
+                    class="blue white--text"
+                    close
+                    @click:close="removeCountry(data.item)"
+                  >
                     {{ data.item.name }}
                   </v-chip>
                 </template>
@@ -440,7 +444,11 @@
           this.error = this.recordUpdate.error;
           this.error_message = this.recordUpdate.message.data;
         }
-      }
+      },
+      removeCountry: function(country){
+        const _module = this;
+        _module.countries = _module.countries.filter(obj => obj.label !== country.name && obj.id !== country.id);
+      },
     },
   }
 </script>

--- a/tests/unit/components/Editor/EditGeneralInfo.spec.js
+++ b/tests/unit/components/Editor/EditGeneralInfo.spec.js
@@ -126,4 +126,12 @@ describe("CreateRecord.vue", function() {
         await wrapper.vm.editRecord();
         expect($router.push).toHaveBeenCalledTimes(1);
     });
+
+    it("removes countries on click", () => {
+        expect(wrapper.vm.countries.length).toEqual(2);
+        let preserved = wrapper.vm.countries[1]
+        wrapper.vm.removeCountry(wrapper.vm.countries[0]);
+        expect(wrapper.vm.countries.length).toEqual(1);
+        expect(wrapper.vm.countries[0]).toBe(preserved);
+    });
 });


### PR DESCRIPTION
This works. But, when a country is dismissed by click, the drawer pops open. I'm not keen on this but, unfortunately, it appears to be a bug in Vue.js that adding styling to an autocomplete produces this behaviour. Example:
https://stackoverflow.com/questions/60577675/how-to-prevent-v-autocomplete-from-opening-the-dropdown-drawer-when-clicking-on
If no-one objects to the behaviour here then it might suffice. 
Of course, someone who is actually a Javascript programmer may think of a means to fix this. ;-)