### PR TITLE
Added legacy collection name link #906.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -209,6 +209,12 @@ let routes = [
             isLoggedIn(to, from, next, store);
         }
     },
+    /* To enable old links to collections to work */
+    {
+        name: "CollectionRecord",
+        path: "/collection/:id",
+        redirect: "/:id"
+    },
     {
         name: "Record",
         path: "/:id",


### PR DESCRIPTION
This will redirect to /:id if someone goes to /collection/:id.
The latter format is used on the old site and so there might be some collections linked elsewhere. 