### PR TITLE
Add schema icon

### DIFF
--- a/src/plugins/icons.js
+++ b/src/plugins/icons.js
@@ -224,6 +224,10 @@ const customIcons  = {
         home_policies: {
             type: "img",
             icon: "assets/Home/BlockInfo/home-policies.svg"
+        },
+        schema_file: {
+            type: "icon",
+            icon: "fa fa-file-alt"
         }
     },
     iconfont: 'fa'

--- a/src/plugins/icons.js
+++ b/src/plugins/icons.js
@@ -229,6 +229,10 @@ const customIcons  = {
             type: "icon",
             icon: "fa-ellipsis-h"
         },
+        schema_file: {
+            type: "icon",
+            icon: "fa fa-file-alt"
+        }
     },
     iconfont: 'fa'
 };


### PR DESCRIPTION
due to a bug that does not allow the schema_file to be saved in editor dashboard, the app is not able to show that in support and a ticket is created for that but the icon is tested by me and definition is correct in the icon files. after this ticket is merged we will be left with no icon to include for support. 

ticket for the spotted bug:
https://github.com/FAIRsharing/fairsharing.github.io/issues/1031

icon for schema_file will be this:

![image](https://user-images.githubusercontent.com/25683981/121007107-950c7280-c789-11eb-94dd-e067ef8a1ac9.png)
