### PR TITLE
Fix support links

### DIFF
--- a/src/components/Editor/DataAccess/EditSupportLinks.vue
+++ b/src/components/Editor/DataAccess/EditSupportLinks.vue
@@ -282,7 +282,7 @@
             id: null,
             template: {
               type: null,
-              url: null,
+              url: {url: null},
               name: null
             }
           }

--- a/src/data/SupportLinksTypes.json
+++ b/src/data/SupportLinksTypes.json
@@ -6,7 +6,6 @@
   "TeSS links to training materials": "api",
   "Wikipedia": "url",
   "Blog/News": "url",
-  "Schema file": "url",
   "Github": "url",
   "Support email": "email",
   "Contact form": "url",

--- a/tests/unit/components/Editor/DataAccess/EditSupportLinks.spec.js
+++ b/tests/unit/components/Editor/DataAccess/EditSupportLinks.spec.js
@@ -78,7 +78,7 @@ describe("Edit -> EditSupportLinks.vue", function() {
            id: null,
            template: {
                type: null,
-               url: null,
+               url: {url: null},
                name: null
            }
        })


### PR DESCRIPTION
This removes the schema_file type (#1030) and also fixes the console bugs (#1031).
Please try adding and removing some support links to check all is OK. Usually, the console errors are seen only on the first attempt to set a support link type and don't recur until after a page refresh. 