### PR TITLE
Fix hiding undefined pubmed link bug

### DIFF
--- a/src/components/Records/Record/GeneralInfo/Citations.vue
+++ b/src/components/Records/Record/GeneralInfo/Citations.vue
@@ -79,7 +79,8 @@
                     {{ $vuetify.breakpoint.lgAndUp?truncate(publication.authors,100):truncate(publication.authors,30) }}
                     ({{ publication.year }})
                     <a
-                      :href="'https://pubmed.ncbi.nlm.nih.gov/' + citation.pubmed_id"
+                      v-if="citation.pubmed_id"
+                      :href="`https://pubmed.ncbi.nlm.nih.gov/${citation.pubmed_id}`"
                       target="_blank"
                     >
                       {{ citation.doi }}


### PR DESCRIPTION
no more showing undefined pubmedID link when data not available

please check record 
http://localhost:8080/#/3204

![image](https://user-images.githubusercontent.com/25683981/121347628-514b7180-c91f-11eb-9432-6195f5c8a866.png)
