### PR TITLE
Orgs and tombstones

### DIFF
--- a/src/components/Records/Record/Organisations.vue
+++ b/src/components/Records/Record/Organisations.vue
@@ -39,7 +39,7 @@
               outlined
             >
               <a
-                :href="organisationLink.organisation.homepage"
+                :href="'/#/organisations/' + organisationLink.organisation.id"
                 target="_blank"
                 class="underline-effect"
               >

--- a/src/views/Errors/Tombstone.vue
+++ b/src/views/Errors/Tombstone.vue
@@ -2,7 +2,7 @@
   <v-container fluid>
     <v-alert type="warning">
       This record does not exist anymore: {{ record.name }}.
-      The record with identifier <b>{{ record.doi }}</b> was invalid.
+      The record with DOI <b>{{ record.doi }}</b> was invalid.
     </v-alert>
     <b class="pl-3">Description: </b> {{ record.description }}
   </v-container>

--- a/src/views/Organisations/Organisation.vue
+++ b/src/views/Organisations/Organisation.vue
@@ -4,7 +4,7 @@
     fluid
     class="standard grey lighten-3 pb-10"
   >
-    <div v-if="error">
+    <div v-if="error && !loading">
       <NotFound />
     </div>
     <v-row v-else>


### PR DESCRIPTION
This addresses three small issues at once:

1. Linking to organisation pages from a record page (https://github.com/FAIRsharing/fairsharing.github.io/issues/1043).
2. Fixing a bug where a 404 message will show whilst an organisation loads.
3. Changing the text for tombstoned records (https://github.com/FAIRsharing/fairsharing.github.io/issues/1038).

Record 478 has `metadata['tombstone'] = true` if you wish to look. Most records (e.g. Genbank ;-) should have organisations. 