### PR TITLE
Citation switch 1096

### DIFF
--- a/src/components/Editor/EditPublications.vue
+++ b/src/components/Editor/EditPublications.vue
@@ -272,13 +272,6 @@
                         :rules="[rules.isRequired()]"
                       />
                     </v-col>
-                    <v-col class="col-12">
-                      <v-switch
-                        v-model="newPublication.isCitation"
-                        color="primary"
-                        label="Do you want to cite this record using this publication?"
-                      />
-                    </v-col>
                   </v-row>
                 </v-container>
               </v-card-text>

--- a/src/components/Records/Record/GeneralInfo/DeprecationReason.vue
+++ b/src/components/Records/Record/GeneralInfo/DeprecationReason.vue
@@ -4,7 +4,7 @@
     v-if="currentRecord.fairsharingRecord.metadata['deprecation_reason']"
     v-linkified:options="{ className: 'underline-effect' }"
     class="mt-5 red--text"
-    v-html="currentRecord.fairsharingRecord.metadata['deprecation_reason']"
+    v-html="$sanitize(currentRecord.fairsharingRecord.metadata['deprecation_reason'])"
   />
   <!-- eslint-enable vue/no-v-html -->
 </template>


### PR DESCRIPTION
I've dealt with this buggy switch by removing it as @terazus planned to do; it is not needed as the user may still set the publication as a citation without it. 