### PR TITLE
fix bug with licences object with no length

### DIFF
--- a/src/components/Records/Record/DataConditions.vue
+++ b/src/components/Records/Record/DataConditions.vue
@@ -1,6 +1,6 @@
 <template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
   <v-card
-    v-if="Object.keys(getField('metadata')).includes('data_processes') || (getField('licences'))"
+    v-if="Object.keys(getField('metadata')).includes('data_processes') || (getField('licences') && getField('licences').length)"
     class="pa-4 d-flex flex-column"
     outlined
     color="bg_record_card"


### PR DESCRIPTION
fix the bug in the relevant ticket in some records with license object with no length, DataCondtion was active mistakenly. 

record had the issue before and now fixed:
http://localhost:8080/#/FAIRsharing.pd7q00
http://localhost:8080/#/1252