### PR TITLE
Showing organisations on a user page

### DIFF
--- a/src/components/Users/Profiles/Private/OrganisationsTable.vue
+++ b/src/components/Users/Profiles/Private/OrganisationsTable.vue
@@ -45,15 +45,6 @@ export default {
   props: {
     organisations: { type: Array, default: null }
   },
-  methods: {
-    objToList(obj) {
-      let names = [];
-      obj.forEach((t) => {
-        names.push(t.name)
-      })
-      return names.join(", ");
-    }
-  },
   computed: {
     ...mapState('users', ['user']),
     headers() {
@@ -70,7 +61,16 @@ export default {
     footer(){
       return {'items-per-page-options': [5]}
     }
-  }
+  },
+  methods: {
+    objToList(obj) {
+      let names = [];
+      obj.forEach((t) => {
+        names.push(t.name)
+      })
+      return names.join(", ");
+    }
+  },
 }
 </script>
 

--- a/src/components/Users/Profiles/Private/OrganisationsTable.vue
+++ b/src/components/Users/Profiles/Private/OrganisationsTable.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <v-data-table
+      class="userProfileOrganistionsTable"
+      :items="organisations"
+      :headers="headers"
+      :items-per-page="perPage"
+      :footer-props="footer"
+      calculate-widths
+    >
+      <template #[`item.name`]="{ item }">
+        <router-link
+          :to="'/organisations/' + item.id"
+        >
+          {{ item.name }}
+        </router-link>
+      </template>
+
+      <template #[`item.homepage`]="{ item }">
+        <router-link
+          :to="item.homepage"
+        >
+          {{ item.homepage }}
+        </router-link>
+      </template>
+
+      <template #[`item.organisationTypes`]="{ item }">
+        {{ objToList(item.organisationTypes) }}
+      </template>
+
+      <template slot="no-data">
+        <div>
+          You are not a member of any organisations.
+        </div>
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script>
+import {mapState} from "vuex";
+
+export default {
+  name: "OrganisationsTable",
+  props: {
+    organisations: { type: Array, default: null }
+  },
+  methods: {
+    objToList(obj) {
+      let names = [];
+      obj.forEach((t) => {
+        names.push(t.name)
+      })
+      return names.join(", ");
+    }
+  },
+  computed: {
+    ...mapState('users', ['user']),
+    headers() {
+      let headers = [
+        {text: 'Name', value: 'name', align: 'center'},
+        {text: 'Types', value: 'organisationTypes', align: 'center'},
+        {text: 'Homepage', value: 'homepage', align: 'center'},
+      ];
+      return headers;
+    },
+    perPage(){
+      return 5;
+    },
+    footer(){
+      return {'items-per-page-options': [5]}
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/Users/Profiles/Private/RecordsTable.vue
+++ b/src/components/Users/Profiles/Private/RecordsTable.vue
@@ -138,7 +138,7 @@
                     createdRecords: "You did not create any record yet. Start creating one ",
                     maintainedRecords: "You do not maintain any records.",
                     publicMaintainedRecords: "This user does not maintain any records.",
-                    watchedRecords: "You are not watching any record"
+                    watchedRecords: "You are not watching any record."
                 }[this.source];
             },
             perPage(){

--- a/src/lib/GraphClient/queries/getPublicUserMeta.json
+++ b/src/lib/GraphClient/queries/getPublicUserMeta.json
@@ -11,6 +11,20 @@
     "orcid",
     "username",
     "twitter",
-    {"$ref": "maintainedRecords"}
+    {"$ref": "maintainedRecords"},
+    {
+      "name": "organisations",
+      "fields": [
+        "id",
+        "name",
+        "homepage",
+        {
+          "queryName": "organisationTypes",
+          "fields": [
+            "name"
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/src/lib/GraphClient/queries/getUserMeta.json
+++ b/src/lib/GraphClient/queries/getUserMeta.json
@@ -23,6 +23,20 @@
     {"$ref": "createdRecords"},
     {"$ref": "maintainedRecords"},
     {"$ref": "recordsInCuration"},
-    {"$ref": "watchedRecords"}
+    {"$ref": "watchedRecords"},
+    {
+      "name": "organisations",
+      "fields": [
+        "id",
+        "name",
+        "homepage",
+        {
+          "queryName": "organisationTypes",
+          "fields": [
+            "name"
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/src/views/Users/PublicProfile.vue
+++ b/src/views/Users/PublicProfile.vue
@@ -179,6 +179,33 @@
                 </v-card-text>
               </v-card>
             </v-col>
+            
+            <v-col
+              class="pt-0"
+              cols="12"
+              xl="4"
+              lg="6"
+              md="12"
+              sm="12"
+              xs="12"
+            >
+              <v-card
+                height="100%"
+                class="d-flex flex-column rounded-0"
+              >
+                <v-card-title class="primary white--text py-3">
+                  Organisations
+                </v-card-title>
+                <v-card-text
+                  class="pa-0"
+                  style="flex-grow: 1"
+                >
+                  <OrganisationsTable
+                    :organisations="userData.user.organisations"
+                  />
+                </v-card-text>
+              </v-card>
+            </v-col>
           </v-row>
         </v-container>
       </v-col>
@@ -202,6 +229,7 @@
     import ExternalClient from "@/lib/Client/ExternalClients.js"
     import NotFound from "@/views/Errors/404"
     import RecordsTable from "../../components/Users/Profiles/Private/RecordsTable";
+    import OrganisationsTable from "../../components/Users/Profiles/Private/OrganisationsTable";
     import { cleanString } from "@/utils/stringUtils"
 
     let client = new ExternalClient();
@@ -212,7 +240,7 @@
 
     export default {
       name: "PublicProfile",
-      components: {RecordsTable, Loaders, NotFound, UserProfileMenu},
+      components: {RecordsTable, OrganisationsTable, Loaders, NotFound, UserProfileMenu},
       mixins: [cleanString],
       data: () => {
         return {
@@ -234,6 +262,7 @@
         getPublicUserMeta: function(){
           let userMeta = JSON.parse(JSON.stringify(this.userData.user));
           delete userMeta["maintainedRecords"];
+          delete userMeta["organisations"];
           return userMeta;
         },
       },

--- a/src/views/Users/User.vue
+++ b/src/views/Users/User.vue
@@ -174,6 +174,7 @@
               </v-card>
             </v-col>
 
+
             <v-col
               class="pt-0"
               cols="12"
@@ -285,6 +286,33 @@
                 </v-card-text>
               </v-card>
             </v-col>
+
+            <v-col
+              class="pt-0"
+              cols="12"
+              xl="4"
+              lg="6"
+              md="12"
+              sm="12"
+              xs="12"
+            >
+              <v-card
+                height="100%"
+                class="d-flex flex-column rounded-0"
+              >
+                <v-card-title class="primary white--text py-3">
+                  Organisations
+                </v-card-title>
+                <v-card-text
+                  class="pa-0"
+                  style="flex-grow: 1"
+                >
+                  <OrganisationsTable
+                    :organisations="user().records.organisations"
+                  />
+                </v-card-text>
+              </v-card>
+            </v-col>
           </v-row>
         </v-container>
       </v-col>
@@ -307,6 +335,7 @@
     import Loaders from "@/components/Navigation/Loaders";
     import ExternalClient from "@/lib/Client/ExternalClients.js"
     import RecordsTable from "../../components/Users/Profiles/Private/RecordsTable";
+    import OrganisationsTable from "../../components/Users/Profiles/Private/OrganisationsTable";
     import { cleanString } from "@/utils/stringUtils"
 
     let client = new ExternalClient();
@@ -317,7 +346,7 @@
 
     export default {
       name: "User",
-      components: {RecordsTable, Loaders, UserProfileMenu},
+      components: {RecordsTable, OrganisationsTable, Loaders, UserProfileMenu},
       mixins: [cleanString],
       data: () => {
         return {

--- a/tests/unit/components/Users/Profiles/Private/OrganisationsTable.spec.js
+++ b/tests/unit/components/Users/Profiles/Private/OrganisationsTable.spec.js
@@ -1,0 +1,42 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils"
+import OrganisationsTable from "@/components/Users/Profiles/Private/OrganisationsTable";
+const localVue = createLocalVue();
+
+
+describe('OrganisationTable.vue', () => {
+    let wrapper;
+
+    it("can be mounted", () => {
+        wrapper = shallowMount(OrganisationsTable, {
+            localVue,
+            propsData: {
+                organisations: [],
+            }
+        });
+        const title = "OrganisationsTable";
+        expect(wrapper.name()).toMatch(title);
+        expect(wrapper.vm.perPage).toBe(5)
+    });
+
+    it("can process organisation types", () => {
+        wrapper = shallowMount(OrganisationsTable, {
+            localVue,
+            propsData: {
+                organisations: [],
+            }
+        });
+        let obj = [
+            {
+                name: 'one',
+            },
+            {
+                name: 'two'
+            }
+        ];
+        expect(wrapper.vm.objToList(obj)).toEqual('one, two');
+
+    })
+
+
+
+});


### PR DESCRIPTION
This PR adds UI elements relating to the ticket here:

https://github.com/FAIRsharing/FAIRsharing-API/issues/298

Also:

https://github.com/FAIRsharing/fairsharing.github.io/issues/1098

Specifically, displaying the organisations to which a user belongs on their page. Other changes relating to these tickets will come in separate PRs for easier review. 

Take a look at my record (/users/659) for an example.