### PR TITLE
Added link from record page chips to search page.  #1120.

### DIFF
--- a/src/components/Records/Record/GeneralInfo/Keywords.vue
+++ b/src/components/Records/Record/GeneralInfo/Keywords.vue
@@ -13,6 +13,7 @@
           class="mr-2 mb-2 text-capitalize"
           :color="getChipColor(item)"
           text-color="white"
+          @click="returnToSearch('subjects', item.label)"
         >
           <KeywordTooltip
             :keyword="item"
@@ -34,6 +35,7 @@
           class="mr-2 mb-2 text-capitalize"
           :color="getChipColor(item)"
           text-color="white"
+          @click="returnToSearch('domains', item.label)"
         >
           <KeywordTooltip
             :keyword="item"
@@ -55,6 +57,7 @@
           class="mr-2 mb-2 text-capitalize"
           text-color="white"
           :color="getChipColor(item)"
+          @click="returnToSearch('taxonomies', item.label)"
         >
           <KeywordTooltip
             :keyword="item"
@@ -76,6 +79,7 @@
           class="mr-2 mb-2 text-capitalize"
           text-color="white"
           :color="getChipColor(item)"
+          @click="returnToSearch('userDefinedTags', item.label)"
         >
           <KeywordTooltip
             :keyword="item"
@@ -99,6 +103,11 @@ export default {
   mixins: [recordsCardUtils],
   computed: {
     ...mapGetters("record", ["getField"])
+  },
+  methods: {
+    returnToSearch(field, item) {
+      this.$router.push({path: `/search?${field}=${item}`})
+    }
   }
 }
 </script>

--- a/tests/unit/components/Records/Record/GeneralInfo/Keywords.spec.js
+++ b/tests/unit/components/Records/Record/GeneralInfo/Keywords.spec.js
@@ -2,9 +2,15 @@ import { shallowMount, createLocalVue } from "@vue/test-utils";
 import Vuex from "vuex";
 import Record from "@/store/recordData.js"
 import Keywords from "@/components/Records/Record/GeneralInfo/Keywords.vue"
+import VueRouter from "vue-router";
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+
+let $route = {params: {id: "123"}};
+const router = new VueRouter();
+const $router = { push: jest.fn() };
+
 Record.state.currentRecord["fairsharingRecord"] = {
     taxonomies: [
         {label: "Turdus turdus"},
@@ -28,7 +34,8 @@ describe("Keywords.vue", function(){
     beforeEach(() => {
         wrapper = shallowMount(Keywords, {
             localVue,
-            mocks: {$store}
+            router,
+            mocks: {$store, $route, $router}
         });
     });
 
@@ -40,5 +47,9 @@ describe("Keywords.vue", function(){
         expect(wrapper.vm.getField('userDefinedTags').length).toEqual(1);
     });
 
+    it("returns to the search page when a chip is clicked", () => {
+        wrapper.vm.returnToSearch('subjects', 'citizens');
+        expect($router.push).toHaveBeenCalledWith({path: '/search?subjects=citizens'})
+    });
 
 });


### PR DESCRIPTION
To try this out, open any record and click on any of the chips in generalinfo. (e.g. a taxonomy, user_defined_tag etc.). 
You should be sent back to the search page with an appropriate search related to that tag. 