### PR TITLE
Added additional route for full DOIs #1134.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -317,6 +317,11 @@ let routes = [
         redirect: "/:id"
     },
     {
+        name: "RecordByDoi",
+        path: "/10.25504/:id",
+        component: Record
+    },
+    {
         name: "Record",
         path: "/:id",
         component: Record

--- a/src/views/Users/UsersList.vue
+++ b/src/views/Users/UsersList.vue
@@ -19,7 +19,7 @@
         :loading="loading"
         loading-text="Loading... Please wait"
       >
-        <template v-slot:item.id="{ item }">
+        <template #item.id="{ item }">
           <router-link
             class="underline-effect"
             :to="`/users/${item.id}`"


### PR DESCRIPTION
It should now be possible to access a record by DOI if the full doi (inc. 10.25504) is used. See https://github.com/FAIRsharing/fairsharing.github.io/issues/1134#issue-940737958 for details and examples. 