### PR TITLE
Added some text for #1123.

### DIFF
--- a/src/views/Users/EditProfile.vue
+++ b/src/views/Users/EditProfile.vue
@@ -95,6 +95,13 @@
                     get in touch</a>.
                 </p>
 
+                <p
+                  :v-if="!user().metadata.orcid"
+                >
+                  <b>We strongly recommend including your ORCID ID to provide extra information for the FAIRsharing
+                    community about you and the resources you develop.</b>
+                </p>
+
                 <!-- ACTIONS -->
                 <v-row>
                   <v-col cols="12">


### PR DESCRIPTION
If a user goes to edit their own profile via the usual link (/profiles/edit) and hasn't set their ORCID ID they should be shown a message at the bottom of the edit form encouraging them to do so. 