### PR TITLE
Record review 1150

### DIFF
--- a/src/lib/GraphClient/queries/curators/getSummary.json
+++ b/src/lib/GraphClient/queries/curators/getSummary.json
@@ -2,6 +2,7 @@
   "queryName": "curationSummary",
   "queryParam": null,
   "fields": [
+    "needsReview",
     {
       "name": "curatorList",
       "fields": [

--- a/src/views/Curators/Curator.vue
+++ b/src/views/Curators/Curator.vue
@@ -194,21 +194,21 @@
         <v-card>
           <v-card-text>
             <v-card-title
-                id="download-review-needed"
-                class="green white--text"
+              id="download-review-needed"
+              class="green white--text"
             >
               RECORDS NEEDING REVIEW
               <v-btn
-                  v-if="downloadReviewContent"
-                  class="info ml-5"
+                v-if="downloadReviewContent"
+                class="info ml-5"
               >
                 <a
-                    :href="downloadReviewContent"
-                    download="recordsNeedingReview.txt"
+                  :href="downloadReviewContent"
+                  download="recordsNeedingReview.txt"
                 >
                   <v-icon
-                      color="white"
-                      class="mr-1"
+                    color="white"
+                    class="mr-1"
                   >
                     fa fa-download
                   </v-icon>

--- a/src/views/Curators/Curator.vue
+++ b/src/views/Curators/Curator.vue
@@ -191,6 +191,33 @@
             </v-card-title>
           </v-card-text>
         </v-card>
+        <v-card>
+          <v-card-text>
+            <v-card-title
+                id="download-review-needed"
+                class="green white--text"
+            >
+              RECORDS NEEDING REVIEW
+              <v-btn
+                  v-if="downloadReviewContent"
+                  class="info ml-5"
+              >
+                <a
+                    :href="downloadReviewContent"
+                    download="recordsNeedingReview.txt"
+                >
+                  <v-icon
+                      color="white"
+                      class="mr-1"
+                  >
+                    fa fa-download
+                  </v-icon>
+                  <span class="white--text">Obtain file</span>
+                </a>
+              </v-btn>
+            </v-card-title>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
     <v-row v-else>
@@ -267,7 +294,8 @@
             hiddenRecords: ""
           },
           loading: false,
-          downloadContent: null
+          downloadContent: null,
+          downloadReviewContent: null
         }
       },
       computed: {
@@ -294,6 +322,7 @@
           this.prepareData();
           await this.obtainFileRecordsWODois();
           this.loading = false;
+          this.downloadReviewContent = "data:text/json;charset=utf-8," + encodeURIComponent(this.allDataCuration.needsReview.join('\n'));
         })
       },
       methods: {


### PR DESCRIPTION
This adds an additional button to the curator dashboard which supplies a file listing all records which haven't been reviewed by a curator within the last year. 
None of the records will have a previous review date yet as none have ever been reviewed. 