### PR TITLE
Pass parameters when approving

### DIFF
--- a/src/components/Curators/RecordsAwaitingApproval.vue
+++ b/src/components/Curators/RecordsAwaitingApproval.vue
@@ -413,7 +413,8 @@
               let preparedRecord = {
                 approved: true,
                 skip_approval: true,
-                processing_notes: null
+                processing_notes: null,
+                create_review: true
               };
               let data = {
                 record: preparedRecord,


### PR DESCRIPTION
This should cause records which are approved by the super_curator on the curation dashboard to be marked as reviewed by said super_curator. 