### PR TITLE
Added link to all records for an organisation #1397.

### DIFF
--- a/src/views/Organisations/Organisation.vue
+++ b/src/views/Organisations/Organisation.vue
@@ -217,6 +217,16 @@
                 style="min-width: 720px"
               >
                 Records related to this organisation
+                <!-- filter records on search page -->
+                <v-col class="text-right">
+                  <v-btn
+                    color="white"
+                    small
+                    @click="filterRecords"
+                  >
+                    Filter Records
+                  </v-btn>
+                </v-col>
               </v-card-title>
 
               <v-data-table
@@ -510,9 +520,16 @@ export default {
     goToRecord(id) {
       window.open("/" + id, '_blank');
     },
-    hideOverlay(){
+    hideOverlay() {
       this.showOverlay = false;
       this.targetID = null;
+    },
+    filterRecords() {
+      const params = {organisations: encodeURIComponent(this.organisation.name.toLowerCase()) }
+      this.$router.push({
+        name: 'search',
+        query: params
+      });
     }
   }
 }

--- a/tests/unit/views/Organisations/Organisation.spec.js
+++ b/tests/unit/views/Organisations/Organisation.spec.js
@@ -72,6 +72,22 @@ describe("Organisation", () => {
         expect(wrapper.vm.currentRoute).toEqual(1);
     });
 
+    it("redirects to the search page for filtering", async() => {
+        graphStub.restore();
+        wrapper = await shallowMount(Organisation, {
+            localVue,
+            router,
+            mocks: {$route, $router},
+            stubs: {RouterLink: RouterLinkStub}
+        });
+        await wrapper.vm.getOrganisation();
+        wrapper.vm.filterRecords();
+        expect($router.push).toHaveBeenCalledWith({
+            name: "search",
+            query: {organisations: "100-talent%20program%20of%20chinese%20academy%20of%20sciences"}
+        });
+    });
+
     it("doesn't display if the organistion is not set in the response", async () => {
         graphStub.restore();
         graphStub = sinon.stub(GraphClient.prototype, "executeQuery").returns({
@@ -143,4 +159,5 @@ describe("Organisation", () => {
         $route.params.id = 10;
         expect(wrapper.vm.currentRoute).toEqual(10);
     });
+
 });

--- a/tests/unit/views/Organisations/Organisation.spec.js
+++ b/tests/unit/views/Organisations/Organisation.spec.js
@@ -21,37 +21,38 @@ describe("Organisation", () => {
 
     let wrapper;
     let graphStub;
+    let organisation = {
+        id: 1,
+        name: "4DN Data Coordination and Integration Center",
+        alternativeNames: [],
+        homepage: "http://dcic.4dnucleome.org/",
+        types: [
+            "Consortium"
+        ],
+        urlForLogo: "/logo12345678",
+        childOrganisations: [],
+        parentOrganisations: [],
+        organisationLinks: [
+            {
+                id: 6057,
+                isLead: true,
+                relation: "maintains",
+                fairsharingRecord: {
+                    id: 872,
+                    name: "Pairs file format",
+                    abbreviation: ".pairs",
+                    type: "model_and_format",
+                    registry: "Standard",
+                    status: "ready"
+                },
+                "grant": null
+            }
+        ]
+    }
 
     beforeAll(() => {
         graphStub = sinon.stub(GraphClient.prototype, "executeQuery").returns({
-            organisation: {
-                id: 1,
-                name: "4DN Data Coordination and Integration Center",
-                alternativeNames: [],
-                homepage: "http://dcic.4dnucleome.org/",
-                types: [
-                    "Consortium"
-                ],
-                urlForLogo: "/logo12345678",
-                childOrganisations: [],
-                parentOrganisations: [],
-                organisationLinks: [
-                    {
-                        id: 6057,
-                        isLead: true,
-                        relation: "maintains",
-                        fairsharingRecord: {
-                            id: 872,
-                            name: "Pairs file format",
-                            abbreviation: ".pairs",
-                            type: "model_and_format",
-                            registry: "Standard",
-                            status: "ready"
-                        },
-                        "grant": null
-                    }
-                ]
-            }
+            organisation: organisation
         });
     });
 
@@ -81,10 +82,11 @@ describe("Organisation", () => {
             stubs: {RouterLink: RouterLinkStub}
         });
         await wrapper.vm.getOrganisation();
+        wrapper.vm.organisation = organisation;
         wrapper.vm.filterRecords();
         expect($router.push).toHaveBeenCalledWith({
             name: "search",
-            query: {organisations: "100-talent%20program%20of%20chinese%20academy%20of%20sciences"}
+            query: {organisations: encodeURIComponent(organisation.name.toLowerCase())}
         });
     });
 


### PR DESCRIPTION
This adds a link on an organisation page to the search page for all the records in that organisation, allowing further filtering to be done.
As suggested in #1397 I've left the maintenance filtering for the search page. 