### PR TITLE
Catch a complete absence of the server.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -73,7 +73,7 @@ async function bootstrapApp() {
         await store.dispatch("messages/setMessages");
     }
     catch(error) {
-        if (error.response.status === 503) {
+        if (error.response && error.response.status === 503) {
             store.commit("introspection/setMaintenanceMode");
         }
         else {


### PR DESCRIPTION
This small change will allow the app to display a 500 message if there is absolutely no response from the server. 