### PR TITLE
Fix layout shifting before loading pages specially home page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,11 @@
 <template>
   <v-app id="app">
+    <div
+      v-if="loading"
+      style="height:100vh; color: white"
+    >
+      loading-hidden
+    </div>
     <v-navigation-drawer
       v-if="$vuetify.breakpoint.mdAndDown"
       v-model="UIGeneralStatus.drawerVisibilityState"
@@ -39,13 +45,19 @@
         data() {
           return {
             title: null,
+            loading:true,
             subtitle: null
           }
         },
-        computed: {
-            ...mapState('uiController', ["UIGeneralStatus"]),
-            ...mapState('introspection', ["readOnlyMode"]),
-        }
+      computed: {
+        ...mapState('uiController', ["UIGeneralStatus"]),
+        ...mapState('introspection', ["readOnlyMode"]),
+      },
+      async updated() {
+        // very important line of code which prevents layout shifting which is considered as one negative point for SEO
+        await this.$nextTick()
+        this.loading = false;
+      }
     }
 </script>
 


### PR DESCRIPTION
Due to FAIRsharing is a single-page app it is asynchronous and waits for the layout to load, Layout shifting has been happening in the app, especially when opening the home page which has heavy presentational components it takes time to load all component and besides if you notice footer is dispositioned at the very first milliseconds home page is loading. So this branch solves this issue which is one of the things that affects to SEO 


to test it
open 2 tab. one current final fairsharing 
and one tab: this branch

refresh the page and see the behavior difference not only in home page but in other pages such as record Display we had layout jumping. 