### PR TITLE
Hid unnecessary text #1630.

### DIFF
--- a/src/components/Records/Record/GeneralInfo/Badge/InfoBadge.vue
+++ b/src/components/Records/Record/GeneralInfo/Badge/InfoBadge.vue
@@ -14,6 +14,7 @@
           class="mr-1"
         >
           <v-tooltip
+            v-if="showProgressHover"
             bottom
             nudge-bottom="30"
             :open-on-hover="showProgressHover"
@@ -87,7 +88,7 @@ export default {
   props: {
     currentRecord: {default: null, type: Object},
     showProgress: {default: true, type: Boolean},
-    showProgressHover: {default: true, type: Boolean},
+    showProgressHover: {default: false, type: Boolean},
     showTextHover: {default: true, type: Boolean}
   },
   data() {


### PR DESCRIPTION
For this, I have suppressed display of the placeholder text. I don't think there's any reason to show anything given that this part of the badges has not yet been implemented.
Whenever the time comes to do that part then the small changes I've made here can be reversed. 