### PR TITLE
Add alternative names to autocomplete data. #1656

### DIFF
--- a/src/components/Editor/Organisations/LinkOverlay.vue
+++ b/src/components/Editor/Organisations/LinkOverlay.vue
@@ -36,6 +36,7 @@
                 <v-autocomplete
                   v-model="editOrganisationLink.data.organisation"
                   :items="organisations"
+                  :filter="customFilter"
                   item-text="name"
                   item-value="id"
                   outlined
@@ -475,12 +476,12 @@
         }
       },
       methods: {
-        removeCountry(country){
+        removeCountry(country) {
           this.menus.newOrganisation.data.country_ids = this.menus.newOrganisation.data.country_ids.filter(obj =>
               obj.label !== country.name && obj.id !== country.id
           );
         },
-        hideMenu(){
+        hideMenu() {
           this.menus.show = false;
           this.editOrganisationLink.data = {};
           this.editOrganisationLink.id = null;
@@ -518,11 +519,11 @@
           }
           this.menus.newOrganisation.loading = false;
         },
-        async createNewGrant(){
+        async createNewGrant() {
           this.menus.newGrant.loading = true;
           this.menus.newGrant.error = false;
           let data = await restClient.createGrant(this.menus.newGrant.data, this.user().credentials.token);
-          if (!data.error){
+          if (!data.error) {
             let newGrant = {
               name: data.name,
               description: data.description,
@@ -532,19 +533,23 @@
             Vue.set(this.grants, this.grants.length, newGrant);
             this.menus.show = null;
             this.menus.newGrant.data = {};
-          }
-          else {
-              this.menus.newGrant.error = data.error;
+          } else {
+            this.menus.newGrant.error = data.error;
           }
           this.menus.newGrant.loading = false;
         },
-        confirmModifications(){
+        confirmModifications() {
           let data = JSON.parse(JSON.stringify(this.editOrganisationLink.data));
-          if (this.editOrganisationLink.id > -1){
+          if (this.editOrganisationLink.id > -1) {
             Vue.set(this.organisationLinks, this.editOrganisationLink.id, data);
-          }
-          else Vue.set(this.organisationLinks, this.organisationLinks.length, data);
+          } else Vue.set(this.organisationLinks, this.organisationLinks.length, data);
           this.editOrganisationLink.showOverlay = false;
+        },
+        customFilter(item, queryText) {
+          const textToSearch = item.name + " " + item.alternativeNames.join(" ");
+          const searchText = queryText.toLowerCase();
+
+          return textToSearch.toLowerCase().indexOf(searchText) > -1
         }
       }
     }

--- a/src/lib/GraphClient/queries/Organisations/getOrganisations.json
+++ b/src/lib/GraphClient/queries/Organisations/getOrganisations.json
@@ -8,6 +8,7 @@
     "name",
     "homepage",
     "types",
-    "urlForLogo"
+    "urlForLogo",
+    "alternativeNames"
   ]
 }

--- a/tests/unit/components/Editor/Organisations/LinkOverlay.spec.js
+++ b/tests/unit/components/Editor/Organisations/LinkOverlay.spec.js
@@ -169,4 +169,8 @@ describe("Edit -> LinkOverlay.vue", function() {
         restStub.restore();
     });
 
+    it('can run a custom filter on autocompletes', () => {
+        expect(wrapper.vm.customFilter({name: "this", alternativeNames: []}, "that")).toBe(false);
+        expect(wrapper.vm.customFilter({name: "this", alternativeNames: []}, "this")).toBe(true);
+    });
 });


### PR DESCRIPTION
This requests alternative names from the server (previously not available) to allow filtering of them in the client's autocomplete by means of simple text comparison. 

Best to try this after approx. 14:00 today to give time for indexes to be rebuilt. 