### PR TITLE
Allow access_method to be displayed in "additional info."

### DIFF
--- a/src/components/Records/Record/AdditionalInfo/DatasetArray.vue
+++ b/src/components/Records/Record/AdditionalInfo/DatasetArray.vue
@@ -32,6 +32,17 @@
         </div>
       </div>
 
+      <!--  AccessMethod   -->
+      <div
+        v-if="item.access_method"
+        class="d-flex flex-row align-center min-height-40"
+      >
+        <b class="width-200">Access Method</b>
+        <div class="d-flex full-width ml-md-12 ml-13">
+          {{ item.access_method }}
+        </div>
+      </div>
+
       <!--  URL    -->
       <div
         v-if="item.url"
@@ -132,7 +143,6 @@
           </p>
         </div>
       </div>
-
 
       <v-divider v-if="currentField.length-1!==index" />
     </div>


### PR DESCRIPTION
This relates to: https://github.com/FAIRsharing/FAIRsharing-API/pull/493
Currently, the existing editor code allows the new objects to be edited. They will show up in a record's "additional info." section with the exception of the access_method field. I've added that so that these data can be viewed.

Of course, there's a request in Gitbook to produce a fancy new means of viewing these data, but this modification will mean that they can be viewed whilst we wait for that to be done. 

To try it out:

1. Switch the server to the data_process_merge_484 branch and run `RAILS_ENV=development rake schemas:reload `.
2. Edit a record to add one of the new objects.
3. Exit the editor - all fields should appear in the "additional info." section. 