### PR TITLE
Fix for incorrect token expiry check #1509.

### DIFF
--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -37,8 +37,9 @@ export const initUserDataState = function(){
 };
 
 export const validateToken = function(tokenExpiry){
-    let now = new Date();
-    return now.getTime() - tokenExpiry*1000 < 0;
+    const now = new Date();
+    const exp = new Date(tokenExpiry);
+    return now < exp;
 };
 
 export function initEditorSections(data, sectionsNames){

--- a/tests/unit/store/users.spec.js
+++ b/tests/unit/store/users.spec.js
@@ -28,13 +28,12 @@ describe('Actions/Mutations', () => {
     });
 
     it("Login: testing no user and valid token", async () => {
-        let now = new Date();
         getStub.withArgs("user").returns(JSON.stringify({
             credentials: {
                 username: "Terazus",
                 token: "123",
                 id: 1,
-                tokenValidity: now.getTime()
+                tokenValidity: '2050-01-01'
             }
         }));
         let state = {};
@@ -49,7 +48,7 @@ describe('Actions/Mutations', () => {
                 username: "Terazus",
                 token: "123",
                 id: 1,
-                tokenValidity: "100039"
+                tokenValidity: "1912-04-14"
             }
         }));
         await actions.login(state);


### PR DESCRIPTION
This might fix the login problems described in #1509.
It can only be tried locally, not on Netlify, and only by users who have an account in ORCID's sandbox:

https://info.orcid.org/documentation/integration-guide/sandbox-testing-server/

If it's working then logging in with ORCID and then refreshing or clicking any other link on the page will not result in being logged out again. 