### PR TITLE
Some styling for error messages #889.

### DIFF
--- a/src/components/Editor/Alerts.vue
+++ b/src/components/Editor/Alerts.vue
@@ -8,8 +8,16 @@
         :type="message.type()"
         class="mb-0"
       >
-        <span v-if="!message.error">{{ message.value }}</span>
-        <span v-else>{{ message.value.response.data }}</span>
+        <span v-if="!message.error">
+          {{ message.value }}
+        </span>
+        <vue-json-pretty
+          v-else
+          :data="message.value.response.data"
+          :show-double-quotes="false"
+          :deep="5"
+          :highlight-mouseover-node="true"
+        />
       </v-alert>
     </v-card-text>
   </v-scroll-x-transition>
@@ -17,9 +25,11 @@
 
 <script>
     import { mapGetters } from "vuex"
+    import VueJsonPretty from 'vue-json-pretty';
 
     export default {
         name: "Alerts",
+        components: { VueJsonPretty },
         props: {
             target: {default: null, type: String},
         },
@@ -36,3 +46,12 @@
         }
     }
 </script>
+
+<style>
+.vjs-value__string {
+  color: #e6ee1b !important;
+}
+.vjs-value__boolean, .vjs-value__number {
+  color: #9ac2e5;
+}
+</style>


### PR DESCRIPTION
This addresses #889 by using the same technique as used for logs; the method I used for login errors messes with important aspects of the format of error messages when editing records. 
As it is difficult to force messages to appear, here are a couple of examples I made earlier:
<img width="2270" alt="Screenshot 2022-06-15 at 16 34 42" src="https://user-images.githubusercontent.com/3583375/173869923-47f4ac48-83c7-480a-9028-2977e45637f9.png">
<img width="631" alt="Screenshot 2022-06-15 at 16 32 56" src="https://user-images.githubusercontent.com/3583375/173869934-bd50f268-471d-42aa-8d5c-8135e2bda1fa.png">

I am tempted to apply this to the login error messages as well. 
