### PR TITLE
Added link text as #1778 (but modified).

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bibtex": "^0.9.0",
     "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.16.0",
+    "cache-loader": "^4.1.0",
     "core-js": "^3.6.5",
     "deep-object-diff": "^1.1.0",
     "dotenv": "^8.2.0",
@@ -54,7 +55,8 @@
     "vue-sanitize": "^0.2.1",
     "vue-scrollto": "^2.20.0",
     "vuetify": "2.3.4",
-    "vuex": "^3.5.1"
+    "vuex": "^3.5.1",
+    "webpack": "^4.46.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.16.7",

--- a/src/components/Editor/Alerts.vue
+++ b/src/components/Editor/Alerts.vue
@@ -19,7 +19,7 @@
           :highlight-mouseover-node="true"
         />
         <span v-if="message.error">
-          <br/>
+          <br>
           Need help with the message above?
           Please <a href="mailto:contact@fairsharing.org">email us</a> with the details.
         </span>

--- a/src/components/Editor/Alerts.vue
+++ b/src/components/Editor/Alerts.vue
@@ -18,6 +18,11 @@
           :deep="5"
           :highlight-mouseover-node="true"
         />
+        <span v-if="message.error">
+          <br/>
+          Need help with the message above?
+          Please <a href="mailto:contact@fairsharing.org">email us</a> with the details.
+        </span>
       </v-alert>
     </v-card-text>
   </v-scroll-x-transition>


### PR DESCRIPTION
This adds a message below any errors inviting users to email us if they have a problem with it.
In the example I've covered up the (unimportant) message, but the text is visible.
![Screenshot_20220819_142940](https://user-images.githubusercontent.com/3583375/185629952-39579efb-3be5-4d00-b199-c9fb115b1b1e.png)
Some changes to package.json were necessitated by issues trying to build and run tests. 
 