### PR TITLE
Updating display 

### DIFF
--- a/src/components/Records/Record/DataProcessesAndConditions/OtherDataProcesses.vue
+++ b/src/components/Records/Record/DataProcessesAndConditions/OtherDataProcesses.vue
@@ -79,7 +79,9 @@ export default {
 
         for (const key of otherDataTypes) {
           if (Object.prototype.hasOwnProperty.call(this.getField('metadata'), key)) {
-            this.setAvailableData(this.getField('metadata')[key], key);
+            if (Object.keys(this.getField('metadata')[key]).length) {
+              this.setAvailableData(this.getField('metadata')[key], key);
+            }
           }
         }
       }

--- a/src/components/Records/Record/DataProcessesAndConditions/OtherDatasetArray.vue
+++ b/src/components/Records/Record/DataProcessesAndConditions/OtherDatasetArray.vue
@@ -11,11 +11,13 @@
       class="full-width min-width-200 max-width-200"
     >
       <a
+        v-if="currentItem.url"
         class="underline-effect"
         :href="currentItem.url"
         target="_blank"
       >{{ currentItem.name }}
       </a>
+      <span v-else>{{ currentItem.name }}</span>
     </div>
 
     <!--  Type    -->
@@ -24,11 +26,13 @@
       class="full-width min-width-200 max-width-200"
     >
       <a
+        v-if="currentItem.url"
         class="underline-effect"
         :href="currentItem.url"
         target="_blank"
       >{{ currentItem.type }}
       </a>
+      <span v-else>{{ currentItem.type }}</span>
     </div>
 
     <!--  URLs    -->


### PR DESCRIPTION
Ticket: https://github.com/FAIRsharing/fairsharing.github.io/issues/1817

WDID:
1) If any attribute does not have a data, it will not be displayed in the block e.g in screen shot below ```Resource Sustainability``` does not have any data so field is not displayed
2) If any attribute have only name/type like ```Data Preservation Policy``` in the screenshot and no url, it will be displayed a normal text instead of hyperlink 

<img width="674" alt="image" src="https://user-images.githubusercontent.com/109139583/188126518-de594654-9dbb-435b-8654-0c08a4bab253.png">
