### PR TITLE
Mocked document in StatisticsBlock.spec.js

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -4,3 +4,7 @@ import Particles from "particles.vue";
 
 Vue.use(Particles);
 Vue.use(Vuetify);
+
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest-offline": "^1.0.1",
     "jquery": "^3.5.1",
     "jsdoc-vuex-plugin": "^1.0.0",
+    "jsdom": "^20.0.0",
     "lodash": "^4.17.20",
     "moment": "^2.29.1",
     "node-gyp": "^3.8.0",

--- a/tests/unit/components/Home/StatisticsBlock.spec.js
+++ b/tests/unit/components/Home/StatisticsBlock.spec.js
@@ -5,6 +5,11 @@ import Vuex from "vuex"
 import RestClient from "@/lib/Client/RESTClient.js"
 const sinon = require("sinon");
 
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM();
+global.document = dom.window.document;
+global.window = dom.window;
+
 const localVue = createLocalVue();
 localVue.use(Vuex)
 const vuetify = new Vuetify();


### PR DESCRIPTION
I was getting a warning running tests locally due to document being  null (see ` const counters = document.querySelectorAll(".counter");`) and this PR adds a mock for it. 
