### PR TITLE
Changed construction of string for large numbers.

### DIFF
--- a/src/components/Home/StatisticsBlock.vue
+++ b/src/components/Home/StatisticsBlock.vue
@@ -127,15 +127,15 @@ export default {
     updateNumbers (labelValue) {
       // Nine Zeroes for Billions
       if (labelValue >= 1.0e+9) {
-        return Math.abs(Number(labelValue)) / 1.0e+9 + "B"
+        return Math.round(Number(labelValue) / 1.0e+9) + "B"
       }
       // Six Zeroes for Millions
       else if (labelValue >= 1.0e+6) {
-        return Math.abs(Number(labelValue)) / 1.0e+6 + "M"
+        return Math.round(Number(labelValue) / 1.0e+6) + "M"
       }
       // Three Zeroes for Thousands
       else if (labelValue >= 1.0e+4) {
-        return Math.abs(Number(labelValue)) / 1.0e+3 + "K"
+        return Math.round(Number(labelValue) / 1.0e+3) + "K"
       }
       else{
         return  labelValue


### PR DESCRIPTION
I spotted this when I deployed to master; seems to have crept in since I last looked:

<img width="447" alt="Screenshot 2022-09-09 at 16 19 06" src="https://user-images.githubusercontent.com/3583375/189385146-ddda02e1-ff70-43aa-831a-b2753b0b648e.png">

This commit should fix it. 