### PR TITLE
hide attributes-and-conditions block when no data

### DIFF
--- a/src/components/Records/Record/DataProcessesAndConditions.vue
+++ b/src/components/Records/Record/DataProcessesAndConditions.vue
@@ -62,7 +62,7 @@
         </v-card>
       </div>
       <!-- Other data items component -->
-      <div v-if="(getField('metadata')['data_access_condition'] && Object.keys('data_access_condition').length) || (getField('metadata')['data_curation'] && Object.keys('data_curation').length) ||(getField('metadata')['data_deposition_condition'] && Object.keys('data_deposition_condition').length) ||(getField('metadata')['data_preservation_policy'] && Object.keys('data_preservation_policy').length)">
+      <div v-if="(getField('metadata')['data_access_condition'] && Object.keys(getField('metadata')['data_access_condition']).length) || (getField('metadata')['data_curation'] && Object.keys(getField('metadata')['data_curation'] ).length) ||(getField('metadata')['data_deposition_condition'] && Object.keys(getField('metadata')['data_deposition_condition']).length) ||(getField('metadata')['data_preservation_policy'] && Object.keys(getField('metadata')['data_preservation_policy']).length)">
         <OtherDataProcesses />
       </div>
     </div>


### PR DESCRIPTION
Ticket : https://github.com/FAIRsharing/fairsharing.github.io/issues/1839

WDID:
Hide the ```Attributes and Conditions``` block when no data is present


![image](https://user-images.githubusercontent.com/109139583/192002976-87d72bf1-23f4-48e3-9eec-544779d9d774.png)
