### PR TITLE
Changed preview behaviour to fix #1782

### DIFF
--- a/src/components/Editor/EditRelationships.vue
+++ b/src/components/Editor/EditRelationships.vue
@@ -110,7 +110,7 @@
                             icon
                             class="blue white--text mr-2"
                             v-on="on"
-                            @click="showPreviewOverlay(record)"
+                            @click="viewRecord(record)"
                           >
                             <v-icon small>
                               fas fa-eye
@@ -240,7 +240,7 @@
                           icon
                           class="blue white--text mr-2"
                           v-on="on"
-                          @click="showPreviewOverlay(association.linkedRecord)"
+                          @click="viewRecord(association.linkedRecord)"
                         >
                           <v-icon small>
                             fas fa-eye
@@ -417,22 +417,6 @@
       </v-container>
     </v-dialog>
 
-    <!-- PREVIEW RECORD -->
-    <v-dialog v-model="showPreview">
-      <v-btn
-        fab
-        small
-        class="grey--text absolute"
-        @click="showPreview = false"
-      >
-        <v-icon>fa-times</v-icon>
-      </v-btn>
-
-      <v-card>
-        <Record :target="targetPreview" />
-      </v-card>
-    </v-dialog>
-
     <!-- attempt to add duplicate relationship -->
     <v-snackbar
       v-model="duplicateRelationship"
@@ -448,7 +432,6 @@
     import { mapState, mapActions, mapGetters } from "vuex"
     import { isEqual, capitalize } from "lodash"
     import stringUtils from '@/utils/stringUtils';
-    import Record from "@/views/Records/Record";
     import RecordStatus from "@/components/Records/Shared/RecordStatus";
     import Loaders from "../Navigation/Loaders";
     import Icon from "@/components/Icon";
@@ -457,7 +440,7 @@
 
     export default {
         name: "EditRelationships",
-        components: {Alerts, Icon, Loaders, Record, RecordStatus},
+        components: {Alerts, Icon, Loaders, RecordStatus},
         mixins: [stringUtils],
         data(){
           return {
@@ -470,7 +453,6 @@
             addingRelation: null,
             formValid: false,
             targets: [],
-            showPreview: false,
             targetPreview: null,
             rules: { isRequired: () => {return isRequired()} },
             labelsFilter: {},
@@ -627,9 +609,8 @@
             });
             this.$nextTick(() => {this.$refs['editRecordAssociation'].validate()});
           },
-          showPreviewOverlay(record){
-            this.targetPreview = record.id;
-            this.showPreview = true;
+          viewRecord(record){
+            window.open('/' + record.id, '_blank');
           },
           getRelations() {
             let labelsFilter = {};

--- a/tests/unit/components/Editor/EditRelations.spec.js
+++ b/tests/unit/components/Editor/EditRelations.spec.js
@@ -149,13 +149,6 @@ describe("EditRelationships.vue", function() {
         });
     });
 
-    it('can pop a preview overlay', () => {
-        wrapper.vm.showPreviewOverlay({id: 12});
-        expect(wrapper.vm.targetPreview).toBe(12);
-        expect(wrapper.vm.showPreview).toBe(true);
-        wrapper.vm.showPreview = false;
-    });
-
     it ("can search for records", async () => {
         wrapper.vm.searchFilters.standards = false;
         await wrapper.vm.runSearch();


### PR DESCRIPTION
The fix here was easy - instead of previewing a record when adding relations the button opens a link to that record in a new browser tab. The preview box was overriding the value of currentRecord['fairsharingRecord'] in the edit form, and this can be observed by watching the record ID at the top of the edit form as you click on "view record" eye icons. In this branch it will not change; in dev/master, it will. 