### PR TITLE
adding hashtag to tiles along with popup

### DIFF
--- a/src/data/EducationData.json
+++ b/src/data/EducationData.json
@@ -268,21 +268,24 @@
         "logo": "nutshell.png",
         "text": "",
         "doi": "10.5281/zenodo.7737366",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "nutshell"
       },
       {
         "id": "standards_overview",
         "logo": "standards_overview.png",
         "text": "",
         "doi": "10.5281/zenodo.7737795",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "standards"
       },
       {
         "id": "databases_overview",
         "logo": "databases_overview.png",
         "text": "",
         "doi": "10.5281/zenodo.7737841",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "databases"
       },
       {
         "id": "policies_overview",
@@ -303,21 +306,24 @@
         "logo": "researchers.png",
         "text": "",
         "doi": "10.5281/zenodo.7733025",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "researchers"
       },
       {
         "id": "journal_publishers",
         "logo": "journal_publishers.png",
         "text": "",
         "doi": "10.5281/zenodo.7737417",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "publishers"
       },
       {
         "id": "funders",
         "logo": "funders.png",
         "text": "",
         "doi": "10.5281/zenodo.7737551",
-        "copyButtonStatus": false
+        "copyButtonStatus": false,
+        "hash": "funders"
       },
       {
         "id": "societies_and_alliances",

--- a/src/views/Static/Educational/Educational.vue
+++ b/src/views/Static/Educational/Educational.vue
@@ -208,7 +208,7 @@
     </ul>
     <!-- Infographics dialog box-->
     <v-dialog
-      v-model="inforgraphicPopup.show"
+      v-model="infographicPopup.show"
       class="pa-0"
       max-width="600"
       @click:outside="closeDialog"
@@ -218,8 +218,8 @@
         tile
       >
         <v-img
-          :src="`/assets/Educational/Infographic/${inforgraphicPopup.data.logo}`"
-          class="align-end inforgraphicPopupImage"
+          :src="`/assets/Educational/Infographic/${infographicPopup.data.logo}`"
+          class="align-end infographicPopup"
           contain
           position="top center"
         >
@@ -237,7 +237,7 @@
           class="justify-center"
         >
           <div
-            v-if="inforgraphicPopup.data.doi"
+            v-if="infographicPopup.data.doi"
             class="d-flex align-center"
           >
             <Icon
@@ -247,16 +247,16 @@
               class="mr-2 width-35"
             />
             <a
-              :href="generateDoiLink(inforgraphicPopup.data.doi)"
+              :href="generateDoiLink(infographicPopup.data.doi)"
               target="_blank"
               class="underline-effect font-weight-medium "
               style="word-break: initial;"
             >
-              {{ inforgraphicPopup.data.doi }}
+              {{ infographicPopup.data.doi }}
             </a>
             <v-tooltip top>
               <template #activator="{on, attrs }">
-                <span @click="copyURL(inforgraphicPopup.data)">
+                <span @click="copyURL(infographicPopup.data)">
                   <v-icon
                     v-ripple
                     v-bind="attrs"
@@ -268,16 +268,16 @@
                   </v-icon>
                 </span>
               </template>
-              <span v-if="!inforgraphicPopup.data.copyButtonStatus"> Copy URL </span>
+              <span v-if="!infographicPopup.data.copyButtonStatus"> Copy URL </span>
               <span v-else> URL copied </span>
             </v-tooltip>
           </div>
           <h3
-            v-else-if="inforgraphicPopup.data.text"
+            v-else-if="infographicPopup.data.text"
             style="word-break: initial;"
             class="grey--text text--darken-1"
           >
-            {{ inforgraphicPopup.data.text }}
+            {{ infographicPopup.data.text }}
           </h3>
         </v-card-title>
       </v-card>
@@ -299,7 +299,7 @@
           infographics: infographics["data"],
           applyCss: false,
           selectedExpansion:{},
-          inforgraphicPopup:{
+          infographicPopup:{
             data: {},
             show: false,
             loading: false
@@ -360,9 +360,9 @@
           const hashArray = this.infographics.map(({hash}) => hash)
           const isHash = hashArray.includes(hash)
           if (isHash) {
-            const hashInforgraphic = this.infographics.filter(e => e.hash === hash)
-            _module.inforgraphicPopup = {
-              data: hashInforgraphic[0],
+            const hashInfographic = this.infographics.filter(e => e.hash === hash)
+            _module.infographicPopup = {
+              data: hashInfographic[0],
               show: true,
               loading: true
             };
@@ -370,9 +370,9 @@
         },
         closeDialog(){
           let _module = this;
-          _module.inforgraphicPopup.data = {};
-          _module.inforgraphicPopup.show = false;
-          _module.inforgraphicPopup.show = false;
+          _module.infographicPopup.data = {};
+          _module.infographicPopup.show = false;
+          _module.infographicPopup.show = false;
           _module.$router.replace({hash: ""});
         }
       }
@@ -431,7 +431,7 @@ P {
   top: 0;
   right: 0
 }
-.inforgraphicPopupImage {
+.infographicPopupImage {
   height: 100%;
 }
 

--- a/src/views/Static/Educational/Educational.vue
+++ b/src/views/Static/Educational/Educational.vue
@@ -434,8 +434,5 @@ P {
 .inforgraphicPopupImage {
   height: 100%;
 }
-.inforgraphicPopupImage + div + div {
-  background-size: 100% 100%;
-}
 
 </style>

--- a/src/views/Static/Educational/Educational.vue
+++ b/src/views/Static/Educational/Educational.vue
@@ -206,6 +206,82 @@
         </ul>
       </li>
     </ul>
+    <!-- Infographics dialog box-->
+    <v-dialog
+      v-model="inforgraphicPopup.show"
+      class="pa-0"
+      max-width="600"
+      @click:outside="closeDialog"
+    >
+      <v-card
+        class="full-width fill-height"
+        tile
+      >
+        <v-img
+          :src="`/assets/Educational/Infographic/${inforgraphicPopup.data.logo}`"
+          class="align-end inforgraphicPopupImage"
+          contain
+          position="top center"
+        >
+          <v-card-actions class="justify-end closeInfoPopup">
+            <v-btn
+              x-small
+              fab
+              @click="closeDialog()"
+            >
+              <v-icon> fa-times </v-icon>
+            </v-btn>
+          </v-card-actions>
+        </v-img>
+        <v-card-title
+          class="justify-center"
+        >
+          <div
+            v-if="inforgraphicPopup.data.doi"
+            class="d-flex align-center"
+          >
+            <Icon
+              item="DOI"
+              heigh="30"
+              wrapper-class=""
+              class="mr-2 width-35"
+            />
+            <a
+              :href="generateDoiLink(inforgraphicPopup.data.doi)"
+              target="_blank"
+              class="underline-effect font-weight-medium "
+              style="word-break: initial;"
+            >
+              {{ inforgraphicPopup.data.doi }}
+            </a>
+            <v-tooltip top>
+              <template #activator="{on, attrs }">
+                <span @click="copyURL(inforgraphicPopup.data)">
+                  <v-icon
+                    v-ripple
+                    v-bind="attrs"
+                    class="primary--text ml-2 cursor-pointer"
+                    small
+                    v-on="on"
+                  >
+                    fa fa-copy
+                  </v-icon>
+                </span>
+              </template>
+              <span v-if="!inforgraphicPopup.data.copyButtonStatus"> Copy URL </span>
+              <span v-else> URL copied </span>
+            </v-tooltip>
+          </div>
+          <h3
+            v-else-if="inforgraphicPopup.data.text"
+            style="word-break: initial;"
+            class="grey--text text--darken-1"
+          >
+            {{ inforgraphicPopup.data.text }}
+          </h3>
+        </v-card-title>
+      </v-card>
+    </v-dialog>
   </main>
 </template>
 
@@ -223,6 +299,11 @@
           infographics: infographics["data"],
           applyCss: false,
           selectedExpansion:{},
+          inforgraphicPopup:{
+            data: {},
+            show: false,
+            loading: false
+          }
         }
       },
       watch: {
@@ -258,6 +339,9 @@
         })
         // update the UI padding and margin after DOM is fully loaded.
       },
+      mounted() {
+        this.generatePopup()
+      },
       methods: {
         generateDoiLink(doi) {
           return `https://doi.org/${doi}`
@@ -268,6 +352,28 @@
           const itemClicked = this.infographics.filter(e => e.id === item.id)
           itemClicked[0].copyButtonStatus = !itemClicked[0].copyButtonStatus
 
+        },
+        generatePopup() {
+          let _module = this;
+          let hash = _module.$route.hash;
+          hash = hash.substring(1)
+          const hashArray = this.infographics.map(({hash}) => hash)
+          const isHash = hashArray.includes(hash)
+          if (isHash) {
+            const hashInforgraphic = this.infographics.filter(e => e.hash === hash)
+            _module.inforgraphicPopup = {
+              data: hashInforgraphic[0],
+              show: true,
+              loading: true
+            };
+          }
+        },
+        closeDialog(){
+          let _module = this;
+          _module.inforgraphicPopup.data = {};
+          _module.inforgraphicPopup.show = false;
+          _module.inforgraphicPopup.show = false;
+          _module.$router.replace({hash: ""});
         }
       }
     }
@@ -318,6 +424,18 @@ P {
 
 .fontSize18 {
   font-size: 18px
+}
+
+.closeInfoPopup {
+  position: absolute;
+  top: 0;
+  right: 0
+}
+.inforgraphicPopupImage {
+  height: 100%;
+}
+.inforgraphicPopupImage + div + div {
+  background-size: 100% 100%;
 }
 
 </style>

--- a/tests/unit/views/Static/Educational/Educational.spec.js
+++ b/tests/unit/views/Static/Educational/Educational.spec.js
@@ -83,13 +83,13 @@ describe("Educational.vue", function(){
                 "hash": "nutshell"
             }
         wrapper.vm.$route.hash
-        wrapper.vm.inforgraphicPopup.data = {};
-        wrapper.vm.inforgraphicPopup.show = false;
-        wrapper.vm.inforgraphicPopup.loading = false;
+        wrapper.vm.infographicPopup.data = {};
+        wrapper.vm.infographicPopup.show = false;
+        wrapper.vm.infographicPopup.loading = false;
         wrapper.vm.generatePopup()
-        expect(wrapper.vm.inforgraphicPopup.data).toStrictEqual(selectedInfoGraphic)
-        expect(wrapper.vm.inforgraphicPopup.show).toBe(true)
-        expect(wrapper.vm.inforgraphicPopup.loading).toBe(true)
+        expect(wrapper.vm.infographicPopup.data).toStrictEqual(selectedInfoGraphic)
+        expect(wrapper.vm.infographicPopup.show).toBe(true)
+        expect(wrapper.vm.infographicPopup.loading).toBe(true)
     });
 
 });

--- a/tests/unit/views/Static/Educational/Educational.spec.js
+++ b/tests/unit/views/Static/Educational/Educational.spec.js
@@ -14,7 +14,7 @@ let $route = {
 
 const originalClipboard = { ...global.navigator.clipboard };
 
-describe("Privacy.vue", function(){
+describe("Educational.vue", function(){
     let wrapper;
 
     beforeEach(() => {
@@ -61,6 +61,35 @@ describe("Privacy.vue", function(){
         wrapper.vm.copyURL(selectedInfoGraphic)
         expect(navigator.clipboard.writeText).toBeCalledTimes(1);
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockDoi)
+    });
+
+    it("can generatePopup", () => {
+        const $route = {
+            hash: '#nutshell'
+        }
+        wrapper = shallowMount(Educational, {
+            localVue,
+            vuetify,
+            mocks: {$route},
+            stubs: ['router-link', 'router-view']
+        })
+        const selectedInfoGraphic =
+            {
+                "id": "nutshell",
+                "logo": "nutshell.png",
+                "text": "",
+                "doi": "10.5281/zenodo.7737366",
+                "copyButtonStatus": true,
+                "hash": "nutshell"
+            }
+        wrapper.vm.$route.hash
+        wrapper.vm.inforgraphicPopup.data = {};
+        wrapper.vm.inforgraphicPopup.show = false;
+        wrapper.vm.inforgraphicPopup.loading = false;
+        wrapper.vm.generatePopup()
+        expect(wrapper.vm.inforgraphicPopup.data).toStrictEqual(selectedInfoGraphic)
+        expect(wrapper.vm.inforgraphicPopup.show).toBe(true)
+        expect(wrapper.vm.inforgraphicPopup.loading).toBe(true)
     });
 
 });


### PR DESCRIPTION
Ticket : https://github.com/FAIRsharing/fairsharing.github.io/issues/2024

WDID: Added hashtags (#) to active infographic tiles and generate popup for the respective tile as per comment https://github.com/FAIRsharing/fairsharing.github.io/issues/2024#issuecomment-1472052113


Example URL: https://deploy-preview-2048--fairsharing.netlify.app/educational#standards