### PR TITLE
adding fix to remove v-safe-html warnings

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -10,6 +10,12 @@ vi.mock("@vue/test-utils", async () => {
     const normalized = { ...options };
     const globalConfig = { ...(normalized.global || {}) };
 
+    globalConfig.directives = {
+      "safe-html": {}, // Stub the directive so Vue ignores it
+      ...(globalConfig.directives || {}),
+      ...(normalized.directives || {}),
+    };
+
     if (normalized.propsData && !normalized.props) {
       normalized.props = normalized.propsData;
     }


### PR DESCRIPTION
Adding fix to remove v-safe-html warning while running ```npm run test```.
While running ```npm run test``` below warnings were encountered in the terminal.

<img width="477" height="78" alt="image" src="https://github.com/user-attachments/assets/8eb7f8c1-eabf-4a9b-8fde-6fd905fb21f9" />


After stubbing the safe-html in setup.js file, there are no more warnings
  
  