### PR TITLE
Changed api_doc page to show new schemas and correct API URL #2786

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,6 +1923,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1939,6 +1940,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,6 +1957,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1971,6 +1974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1987,6 +1991,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,6 +2008,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2019,6 +2025,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,6 +2042,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,6 +2059,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2067,6 +2076,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2083,6 +2093,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,6 +2110,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2115,6 +2127,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2131,6 +2144,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,6 +2161,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,6 +2178,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,6 +2195,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2195,6 +2212,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2211,6 +2229,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2227,6 +2246,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,6 +2263,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2259,6 +2280,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2275,6 +2297,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2291,6 +2314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,6 +2331,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2323,6 +2348,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2554,7 +2580,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2576,7 +2602,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2586,7 +2612,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2603,7 +2629,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2676,6 +2702,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2715,6 +2742,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2735,6 +2763,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2755,6 +2784,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2775,6 +2805,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2795,6 +2826,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,6 +2847,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2835,6 +2868,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2855,6 +2889,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,6 +2910,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,6 +2931,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2915,6 +2952,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2935,6 +2973,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2955,6 +2994,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3073,6 +3113,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3086,6 +3127,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3099,6 +3141,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3112,6 +3155,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3125,6 +3169,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3138,6 +3183,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3151,6 +3197,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3164,6 +3211,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3177,6 +3225,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3190,6 +3239,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3203,6 +3253,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3216,6 +3267,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3229,6 +3281,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3242,6 +3295,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3255,6 +3309,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3268,6 +3323,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3281,6 +3337,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3294,6 +3351,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3307,6 +3365,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3320,6 +3379,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3333,6 +3393,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3346,6 +3407,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3359,6 +3421,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3372,6 +3435,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3385,6 +3449,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4199,7 +4264,7 @@
       "version": "20.19.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5518,7 +5583,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5784,7 +5849,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/buffer-xor": {
@@ -6194,7 +6259,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -6210,7 +6275,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -7302,6 +7367,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -8333,7 +8399,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -9528,7 +9594,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -9958,7 +10024,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -11409,7 +11475,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -11714,6 +11780,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12742,7 +12809,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -14155,7 +14222,7 @@
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -14490,7 +14557,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -14501,7 +14568,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15332,7 +15399,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -15351,7 +15418,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -15596,7 +15663,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -15776,7 +15843,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17058,7 +17125,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import "vue-code-highlight/themes/prism-twilight.css";
 import "vue-code-highlight/themes/window.css";
 import HighchartsVue from "highcharts-vue";
 import SimpleAnalytics from "simple-analytics-vue";
-import VueCodeHighlight from "vue-code-highlight";
 import VueGtag from "vue-gtag";
 /* import linkify to turn url within text into an actual url link */
 import linkify from "vue-3-linkify";
@@ -65,7 +64,6 @@ const app = createApp(App)
   .use(HighchartsVue)
   .use(VueScrollTo)
   .use(createMetaManager())
-  .use(VueCodeHighlight)
   .use(Vue3Sanitize)
   .use(VueGtag, {
     config: { id: import.meta.env.VUE_APP_ANALYTICS_ID },

--- a/src/views/Static/APIDoc/APIDoc.vue
+++ b/src/views/Static/APIDoc/APIDoc.vue
@@ -48,8 +48,8 @@
         { 'lato-text-md': $vuetify.display.xlOnly },
       ]"
     >
-      The base URL of the API is <mark>https://api.fairsharing.org</mark>; paths
-      below may only give the route rather than the full URL, e.g.
+      The base URL of the API is <mark v-text="apiEndpoint" />. Paths below may
+      only give the route rather than the full URL, e.g.
       <mark>/fairsharing_records/123</mark>.
     </p>
 
@@ -60,8 +60,8 @@
         { 'lato-text-md': $vuetify.display.xlOnly },
       ]"
     >
-      You will need to POST the following to
-      <mark>https://api.fairsharing.org/users/sign_in</mark>:
+      You will need to POST the following data to this endpoint:
+      <mark v-text="loginUrl" />
     </p>
 
     <vue-code-highlight class="code-container mt-2 mb-4" language="javascript">
@@ -147,12 +147,12 @@
     </p>
     <vue-code-highlight class="code-container mt-2 mb-4" language="javascript">
       <pre>
-curl --location --request POST 'https://api.fairsharing.org/users/sign_in' \
+curl --location --request POST '{{ loginUrl }}' \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json' \
 --data-raw '{"user": {"login":"your_username","password":"your_secret_password"} }'
 
-curl --location --request GET 'https://api.fairsharing.org/fairsharing_records/1' \
+curl --location --request GET '{{ recordExampleUrl }}' \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer your_jwt_goes_here'
@@ -174,7 +174,7 @@ curl --location --request GET 'https://api.fairsharing.org/fairsharing_records/1
 import requests
 import json
 
-url = "https://api.fairsharing.org/users/sign_in"
+url = "{{ loginUrl }}"
 
 payload={"user": {"login":"your_username","password":"your_password"} }
 headers = {
@@ -188,7 +188,7 @@ response = requests.request("POST", url, headers=headers, data=json.dumps(payloa
 data = response.json()
 jwt = data['jwt']
 
-url = "https://api.fairsharing.org/fairsharing_records/1"
+url = "{{ recordExampleUrl }}"
 
 headers = {
   'Accept': 'application/json',
@@ -217,7 +217,7 @@ print(response.text)
 require "uri"
 require "net/http"
 
-url = URI("https://api.fairsharing.org/users/sign_in")
+url = URI("{{ loginUrl }}")
 
 http = Net::HTTP.new(url.host, url.port)
 request = Net::HTTP::Post.new(url)
@@ -231,7 +231,7 @@ response = http.request(request)
 jwt = response.read_body['jwt']
 
 
-url = URI("https://api.fairsharing.org/fairsharing_records/1")
+url = URI("{{ recordExampleUrl }}")
 
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Get.new(url)
@@ -263,7 +263,7 @@ library(tidyverse)
 library(data.table)
 
 #2. get jwt
-url&lt;-'https://api.fairsharing.org/users/sign_in'
+url&lt;-'{{ loginUrl }}'
 request&lt;-POST(url,
               add_headers(
                 "Content-Type"="application/json",
@@ -273,7 +273,7 @@ con&lt;-jsonlite::fromJSON(rawToChar(request$content))
 auth&lt;-con$jwt
 
 #3. set query
-query_url&lt;-"https://api.fairsharing.org/search/fairsharing_records?fairsharing_registry=database&countries=china&page[number]=1&page[size]=3600"
+query_url&lt;-"{{ chinaDatabaseSearchUrl }}"
 
 get_res&lt;-POST(
   query_url,
@@ -401,7 +401,7 @@ data&lt;-query_con$data
       <li>
         <a
           class="underline-effect"
-          href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/fairsharing_record_schema.json"
+          :href="schemaDocumenterUrl('/model/fairsharing_record_schema.json')"
           target="_blank"
         >
           FAIRsharing Record schema
@@ -415,143 +415,190 @@ data&lt;-query_con$data
       <li>
         <a
           class="underline-effect"
-          href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/database_schema.json"
+          :href="schemaDocumenterUrl('/model/database_schema.json')"
           target="_blank"
         >
           Database schema
         </a>
+        <ul>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/database_knowledgebase_schema.json')
+              "
+              target="_blank"
+            >
+              Pure knowledgebase schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/database_repository_schema.json')
+              "
+              target="_blank"
+            >
+              Pure repository schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl(
+                  '/model/database_knowledgebase_and_repository_schema.json',
+                )
+              "
+              target="_blank"
+            >
+              Combined repository/knowledgebase schema
+            </a>
+          </li>
+        </ul>
       </li>
-      <ul>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/database_knowledgebase_schema.json"
-            target="_blank"
-          >
-            Pure knowledgebase schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/database_repository_schema.json"
-            target="_blank"
-          >
-            Pure repository schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/database_knowledgebase_and_repository_schema.json"
-            target="_blank"
-          >
-            Combined repository/knowledgebase schema
-          </a>
-        </li>
-      </ul>
       <li>
         <a
           class="underline-effect"
-          href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_schema.json"
+          :href="schemaDocumenterUrl('/model/standard_schema.json')"
           target="_blank"
         >
           Standard schema
         </a>
+        <ul>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/standard_identifier_schema.json')
+              "
+              target="_blank"
+            >
+              Identifier schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="schemaDocumenterUrl('/model/standard_metric_schema.json')"
+              target="_blank"
+            >
+              Metric schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="schemaDocumenterUrl('/model/standard_model_schema.json')"
+              target="_blank"
+            >
+              Model/format schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/standard_reporting_schema.json')
+              "
+              target="_blank"
+            >
+              Reporting guideline schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/standard_terminology_schema.json')
+              "
+              target="_blank"
+            >
+              Terminology artifact schema
+            </a>
+          </li>
+        </ul>
       </li>
-      <ul>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_identifier_schema.json"
-            target="_blank"
-          >
-            Identifier schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_metric_schema.json"
-            target="_blank"
-          >
-            Metric schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_model_schema.json"
-            target="_blank"
-          >
-            Model/format schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_reporting_schema.json"
-            target="_blank"
-          >
-            Reporting guideline schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/standard_terminology_schema.json"
-            target="_blank"
-          >
-            Terminology artifact schema
-          </a>
-        </li>
-      </ul>
       <li>
         <a
           class="underline-effect"
-          href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/policy_schema.json"
+          :href="schemaDocumenterUrl('/model/policy_schema.json')"
           target="_blank"
         >
           Policy schema
         </a>
+        <ul>
+          <li>
+            <a
+              class="underline-effect"
+              :href="schemaDocumenterUrl('/model/policy_funder_schema.json')"
+              target="_blank"
+            >
+              Funder schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="schemaDocumenterUrl('/model/policy_journal_schema.json')"
+              target="_blank"
+            >
+              Journal schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="schemaDocumenterUrl('/model/policy_publisher_schema.json')"
+              target="_blank"
+            >
+              Publisher schema
+            </a>
+          </li>
+        </ul>
       </li>
-      <ul>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/policy_funder_schema.json"
-            target="_blank"
-          >
-            Funder schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/policy_journal_schema.json"
-            target="_blank"
-          >
-            Journal schema
-          </a>
-        </li>
-        <li>
-          <a
-            class="underline-effect"
-            href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/policy_publisher_schema.json"
-            target="_blank"
-          >
-            Publisher schema
-          </a>
-        </li>
-      </ul>
       <li>
         <a
           class="underline-effect"
-          href="https://fairsharing.github.io/JSONschema-documenter/?schema_url=https://api.fairsharing.org/model/collection_schema.json"
+          :href="schemaDocumenterUrl('/model/collection_schema.json')"
           target="_blank"
         >
           Collection schema
         </a>
+      </li>
+      <li>
+        <a
+          class="underline-effect"
+          :href="schemaDocumenterUrl('/model/fairassist_schema.json')"
+          target="_blank"
+        >
+          FAIRassist schema
+        </a>
+        <ul>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/fairassist_benchmark_schema.json')
+              "
+              target="_blank"
+            >
+              Benchmark schema
+            </a>
+          </li>
+          <li>
+            <a
+              class="underline-effect"
+              :href="
+                schemaDocumenterUrl('/model/fairassist_metric_schema.json')
+              "
+              target="_blank"
+            >
+              Metric schema
+            </a>
+          </li>
+        </ul>
       </li>
     </ul>
 
@@ -697,7 +744,7 @@ data&lt;-query_con$data
 
     <vue-code-highlight class="code-container mt-2 mb-4" language="ruby">
       <pre>
-        curl --location --request POST 'https://api.fairsharing.org/search/fairsharing_records?q=ADHD&fairsharing_registry=database&countries=china'
+        curl --location --request POST '{{ adhdChinaDatabaseSearchUrl }}'
         --header 'Accept: application/json'
         --header 'Content-Type: application/json'
         --header 'Authorization: Bearer your_jwt_goes_here'
@@ -1090,14 +1137,34 @@ data&lt;-query_con$data
 </template>
 
 <script>
-import { component as VueCodeHighlight } from "vue-code-highlight";
-
 import getHostname from "@/utils/generalUtils";
+import VueCodeHighlight from "./APICodeHighlight.vue";
 
 export default {
   name: "APIDoc",
   components: { VueCodeHighlight },
   mixins: [getHostname],
+  computed: {
+    apiEndpoint() {
+      return import.meta.env.VITE_API_ENDPOINT;
+    },
+    adhdChinaDatabaseSearchUrl() {
+      return this.apiUrl(
+        "/search/fairsharing_records?q=ADHD&fairsharing_registry=database&countries=china",
+      );
+    },
+    chinaDatabaseSearchUrl() {
+      return this.apiUrl(
+        "/search/fairsharing_records?fairsharing_registry=database&countries=china&page[number]=1&page[size]=3600",
+      );
+    },
+    loginUrl() {
+      return this.apiUrl("/users/sign_in");
+    },
+    recordExampleUrl() {
+      return this.apiUrl("/fairsharing_records/1");
+    },
+  },
   data: () => {
     return {
       tables: {
@@ -1263,6 +1330,16 @@ export default {
         },
       },
     };
+  },
+  methods: {
+    apiUrl(path) {
+      const endpoint = String(this.apiEndpoint || "").replace(/\/$/, "");
+      const suffix = path.startsWith("/") ? path : `/${path}`;
+      return `${endpoint}${suffix}`;
+    },
+    schemaDocumenterUrl(path) {
+      return `https://fairsharing.github.io/JSONschema-documenter/?schema_url=${this.apiUrl(path)}`;
+    },
   },
 };
 </script>

--- a/src/views/Static/APIDoc/APIDoc.vue
+++ b/src/views/Static/APIDoc/APIDoc.vue
@@ -1137,8 +1137,45 @@ data&lt;-query_con$data
 </template>
 
 <script>
+import { h } from "vue";
+
 import getHostname from "@/utils/generalUtils";
-import VueCodeHighlight from "./APICodeHighlight.vue";
+
+const VueCodeHighlight = {
+  name: "VueCodeHighlight",
+  props: {
+    language: {
+      type: String,
+      default: "javascript",
+    },
+  },
+  mounted() {
+    this.applyLanguageClass();
+  },
+  updated() {
+    this.applyLanguageClass();
+  },
+  methods: {
+    applyLanguageClass() {
+      const codeBlock = this.$refs.codeBlock;
+      if (!codeBlock) return;
+
+      const languageClass = `language-${this.language}`;
+      codeBlock.querySelectorAll("pre, pre > code").forEach((element) => {
+        element.className = element.className
+          .split(/\s+/)
+          .filter(
+            (className) => className && !className.startsWith("language-"),
+          )
+          .concat(languageClass)
+          .join(" ");
+      });
+    },
+  },
+  render() {
+    return h("div", { ref: "codeBlock" }, this.$slots.default?.());
+  },
+};
 
 export default {
   name: "APIDoc",


### PR DESCRIPTION
This adds links to missing schema files and also changes references to api.fairsharing.org to dev-api.fairsharing.org etc. depending on where the server is running (this should be useful for users trying out our dev site). 